### PR TITLE
Fix problems with widths and signed numbers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -336,3 +336,5 @@ project/plugins/project/
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 
+/src/main/scala/firrtl_interpreter/playground.sc
+/*.vcd

--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ resolvers ++= Seq(
 )
 
 // Provide a managed dependency on X if -DXVersion="" is supplied on the command line.
-val defaultVersions = Map("firrtl" -> "0.2-BETA-SNAPSHOT")
+val defaultVersions = Map("firrtl" -> "0.1-SNAPSHOT")
 
 libraryDependencies ++= (Seq("firrtl").map {
   dep: String => "edu.berkeley.cs" %% dep % sys.props.getOrElse(dep + "Version", defaultVersions(dep)) })

--- a/frepl.sh
+++ b/frepl.sh
@@ -1,0 +1,1 @@
+sbt "run-main firrtl_interpreter.FirrtlRepl"

--- a/src/main/scala/firrtl_interpreter/ConcreteSIntSpec.scala
+++ b/src/main/scala/firrtl_interpreter/ConcreteSIntSpec.scala
@@ -1,0 +1,17 @@
+// See LICENSE for license details.
+
+package firrtl_interpreter
+
+import org.scalatest.{Matchers, FlatSpec}
+
+class ConcreteSIntSpec extends FlatSpec with Matchers {
+  behavior of "constructor"
+
+  it should "throw exception if not enough bits to hold" in {
+    intercept[InterpreterException] {
+      ConcreteSInt(4, 2)
+    }
+  }
+
+  it should "become a negative number if high bit of value is "
+}

--- a/src/main/scala/firrtl_interpreter/FirrtlRepl.scala
+++ b/src/main/scala/firrtl_interpreter/FirrtlRepl.scala
@@ -168,6 +168,7 @@ class FirrtlRepl(replConfig: ReplConfig = ReplConfig()) {
             new StringsCompleter(jlist(Seq("all", "reset", "list")))
           ))
         }
+        // scalastyle:off cyclomatic.complexity
         def run(args: Array[String]): Unit = {
           currentScript match {
             case Some(script) =>
@@ -197,6 +198,8 @@ class FirrtlRepl(replConfig: ReplConfig = ReplConfig()) {
               error(s"No current script")
           }
         }
+        // scalastyle:on cyclomatic.complexity
+
       },
       new Command("vcd") {
         def usage: (String, String) = ("vcd fileName|[done]", "vcd loaded script")

--- a/src/main/scala/firrtl_interpreter/Memory.scala
+++ b/src/main/scala/firrtl_interpreter/Memory.scala
@@ -38,7 +38,7 @@ class Memory(
   import Memory._
 
   val dataWidth    = typeToWidth(dataType)
-  val addressWidth = requiredBits(depth)
+  val addressWidth = requiredBitsForUInt(depth)
   val bigDepth     = BigInt(depth)
   var moduloIndex  = true
 

--- a/src/main/scala/firrtl_interpreter/package.scala
+++ b/src/main/scala/firrtl_interpreter/package.scala
@@ -1,5 +1,6 @@
 // See LICENSE for license details.
 
+//scalastyle:off package.object.name
 package object firrtl_interpreter {
 
   import firrtl._
@@ -27,29 +28,123 @@ package object firrtl_interpreter {
   }
   def ceilingLog2(x: Int): Int = scala.math.ceil(scala.math.log(x) / scala.math.log(2)).toInt
 
+//  /**
+//    * give the minimum number required to hold @num adding one for sign as necessary
+//    *
+//    * @param num the number that must be contained
+//    * @return
+//    */
+//  def requiredBits(num: BigInt): Int = {
+//    // if(num > BitsRequiredOverflowSizeBigInt) {
+//    //   throw new InterpreterException(s"Error:requiredBits num $num > $BitsRequiredOverflowSizeBigInt")
+//    // }
+//    if(num < 2) { 1 + (if(num < 0) 1 else 0) }
+//    else if(num > BitsRequiredOverflowSizeBigInt) {
+//      var width = DangerShiftSize
+//      var comparison = Big1 << width
+//      while(comparison <= num) {
+//        width += 1
+//        comparison <<= 1
+//      }
+//      width
+//    }
+//    else {
+//      val a = num.abs.toDouble + 1.0
+//      (scala.math.ceil(scala.math.log(a) / scala.math.log(2)) + (if(num < 0) 1.0 else 0.0)).toInt
+//    }
+//  }
+
   /**
-    * give the minimum number required to hold @num adding one for sign as necessary
+    * Utility function that computes bits required for a number
     *
-    * @param num the number that must be contained
+    * @param n number of interest
     * @return
     */
-  def requiredBits(num: BigInt): Int = {
-    // if(num > BitsRequiredOverflowSizeBigInt) {
-    //   throw new InterpreterException(s"Error:requiredBits num $num > $BitsRequiredOverflowSizeBigInt")
-    // }
-    if(num < 2) { 1 + (if(num < 0) 1 else 0) }
-    else if(num > BitsRequiredOverflowSizeBigInt) {
-      var width = DangerShiftSize
-      var comparison = Big1 << width
-      while(comparison <= num) {
-        width += 1
-        comparison <<= 1
-      }
-      width
+  def computeBits(n: BigInt): Int = {
+    n.bitLength + (if(n < 0) 1 else 0)
+  }
+//  OLD VERSION IN CASE THE NEED CROPS UP AGAIN
+//  def computeBits(n: BigInt): Int = {
+//    if(n.abs > BitsRequiredOverflowSizeBigInt) {
+//      val num = n.abs
+//      var width = DangerShiftSize
+//      var comparison = Big1 << width
+//      while(comparison <= num) {
+//        width += 1
+//        comparison <<= 1
+//      }
+//      if(n > 0 ) {
+//        width += 1
+//      }
+//      width
+//    }
+//    else {
+//      n.bitLength + (if(n < 0) 1 else 0)
+//    }
+//  }
+
+  /**
+    * computes the smallest and largest values that will fit in an SInt
+    * @param width width of SInt
+    * @return tuple(minVale, maxValue)
+    */
+  def extremaOfSIntOfWidth(width: Int): (BigInt, BigInt) = {
+    val nearestPowerOf2 = BigInt("1" + ("0" * (width - 1)), 2)
+    (-nearestPowerOf2, nearestPowerOf2 - 1)
+  }
+  /**
+    * computes the smallest and largest values that will fit in a UInt
+    * @param width width of SInt
+    * @return tuple(minVale, maxValue)
+    */
+  def extremaOfUIntOfWidth(width: Int): (BigInt, BigInt) = {
+    if(width == 1) {
+      (0, 1)
     }
     else {
-      val a = num.abs.toDouble + 1.0
-      (scala.math.ceil(scala.math.log(a) / scala.math.log(2)) + (if(num < 0) 1.0 else 0.0)).toInt
+      val nearestPowerOf2 = BigInt("1" + ("0" * (width - 1)), 2)
+      (0, (nearestPowerOf2 * 2) - 1)
+    }
+  }
+
+  /**
+    * return the smallest number of bits required to hold the given number in
+    * an SInt
+    * Note: positive numbers will get one minimum width one higher than would be
+    * required for a UInt
+    *
+    * @param num number to find width for
+    * @return minimum required bits for an SInt
+    */
+  def requiredBitsForSInt(num: BigInt): Int = {
+    if(num == Big0 || num == -Big1) {
+      1
+    }
+    else {
+      if (num < 0) {
+        computeBits(num)
+      }
+      else {
+        computeBits(num) + 1
+      }
+    }
+  }
+
+  /**
+    * return the smallest number of bits required to hold the given number in
+    * an UInt
+    * Note: positive numbers will get one minimum width one higher than would be
+    * required for a UInt
+    *
+    * @param num number to find width for
+    * @return minimum required bits for an SInt
+    */
+  def requiredBitsForUInt(num: BigInt): Int = {
+    if(num == Big0) {
+      1
+    }
+    else {
+      computeBits(num)
     }
   }
 

--- a/src/test/scala/firrtl_interpreter/CastingSpec.scala
+++ b/src/test/scala/firrtl_interpreter/CastingSpec.scala
@@ -1,0 +1,89 @@
+// See LICENSE for license details.
+
+package firrtl_interpreter
+
+import firrtl._
+
+import org.scalatest.{Matchers, FlatSpec}
+
+class CastingSpec extends FlatSpec with Matchers {
+  behavior of "requiredBitsForSInt"
+
+  it should "return correct values as specified in list" in {
+    val testData = Map(
+      -9 -> 5, -8 -> 4, -7 -> 4, -6 -> 4, -5 -> 4, -4 -> 3, -3 -> 3, -2 -> 2, -1 -> 1,
+      0 -> 1,
+      1 -> 2, 2 -> 3, 3 -> 3, 4 -> 4, 5 -> 4, 6 -> 4, 7 -> 4, 8 -> 5, 9 -> 5
+    )
+    for((num, width) <- testData) {
+      println(s"test $num expected $width expected ${requiredBitsForSInt(num)}")
+      requiredBitsForSInt(num) should be (width)
+    }
+  }
+
+  behavior of "requiredBitsForUInt"
+
+  it should "return correct values as specified in list" in {
+    val testData = Map(
+      -9 -> 5, -8 -> 4, -7 -> 4, -6 -> 4, -5 -> 4, -4 -> 3, -3 -> 3, -2 -> 2, -1 -> 1,
+      0 -> 1,
+      1 -> 1, 2 -> 2, 3 -> 2, 4 -> 3, 5 -> 3, 6 -> 3, 7 -> 3, 8 -> 4, 9 -> 4
+    )
+    for((num, width) <- testData) {
+      println(s"test $num expected $width expected ${requiredBitsForUInt(num)}")
+      requiredBitsForUInt(num) should be (width)
+    }
+  }
+
+  behavior of "casting ops"
+
+  they should "be able to cast things to SInt and back again" in {
+    val input =
+      """circuit Test :
+        |  module Test :
+        |    input clk : Clock
+        |    input a : UInt<1>
+        |    output c : UInt<2>
+        |    reg w : UInt<1>, clk
+        |    w <= a
+        |    c <= w
+      """.stripMargin
+
+    val interpreter = FirrtlTerp(input)
+    val evaluator = new LoFirrtlExpressionEvaluator(interpreter.dependencyGraph, interpreter.circuitState)
+
+    val u = ConcreteUInt(4, 3)
+    val target = UIntValue(4, IntWidth(3))
+    val s = evaluator.castingOp(AS_SINT_OP, Seq(target), SIntType(IntWidth(3)))
+    println(s"Casted s $s")
+    s.isInstanceOf[ConcreteSInt] should be (true)
+
+    val ss = evaluator.castingOp(AS_UINT_OP, Seq(SIntValue(s.value, IntWidth(s.width))), UIntType(IntWidth(3)))
+    ss.value should be (u.value)
+
+    var testCount = 0
+    for(i <- IntWidthTestValuesGenerator(1, InterpreterMaxSupportedWidth)) {
+      var b1 = Big0
+      val top = BigInt("1"*i, 2)
+      for(b1 <- BigIntTestValuesGenerator(0, top)) {
+        val uiv1 = UIntValue(b1, IntWidth(i))
+        val scv1 = evaluator.castingOp(AS_SINT_OP, Seq(uiv1), SIntType(IntWidth(i)))
+        val siv1 = SIntValue(scv1.value, IntWidth(scv1.width))
+        val ucv2 = evaluator.castingOp(AS_UINT_OP, Seq(siv1), UIntType(IntWidth(i)))
+
+        if(b1.testBit(i-1)) {
+          scv1.value should be < Big0
+          ((top + 1) + scv1.value) should be (b1)
+        }
+        else {
+          scv1.value should be (b1)
+        }
+        ucv2.value should be (b1)
+
+        testCount += 1
+      }
+    }
+    println(s"Test count $testCount")
+  }
+
+}

--- a/src/test/scala/firrtl_interpreter/LoFirrtlExpressionEvaluatorSpec.scala
+++ b/src/test/scala/firrtl_interpreter/LoFirrtlExpressionEvaluatorSpec.scala
@@ -6,9 +6,8 @@ import firrtl._
 import firrtl_interpreter.TestUtils._
 import org.scalatest.{FlatSpec, Matchers}
 
-/**
-  * Created by chick on 4/25/16.
-  */
+// scalastyle:off magic.number
+
 class LoFirrtlExpressionEvaluatorSpec extends FlatSpec with Matchers {
   behavior of "Mux"
 
@@ -72,9 +71,6 @@ class LoFirrtlExpressionEvaluatorSpec extends FlatSpec with Matchers {
 
   val baseWidth = 4
 
-  private def makeSignedBigInt = {
-    BigInt(baseWidth, random) * (if(random.nextBoolean()) 1 else -1)
-  }
   they should "return types correctly" in {
     val w1 = IntWidth(4)
     val w2 = IntWidth(4)
@@ -107,31 +103,35 @@ class LoFirrtlExpressionEvaluatorSpec extends FlatSpec with Matchers {
   they should "evaluate multiply SIntValues correctly" in {
 
     for(i <- 0 to 10) {
-      val w1 = IntWidth(BigInt(baseWidth, random))
-      val w2 = IntWidth(BigInt(baseWidth, random))
-      val i1 = evaluator.makeUIntValue(makeSignedBigInt, w1)
-      val i2 = evaluator.makeUIntValue(makeSignedBigInt, w2)
+      val w1 = IntWidth(BigInt(baseWidth, random).abs + 1)
+      val w2 = IntWidth(BigInt(baseWidth, random).abs + 1)
+
+      val i1 = evaluator.makeSIntValue(BigInt(w1.width.toInt - 1, random), w1)
+      val i2 = evaluator.makeSIntValue(BigInt(w2.width.toInt - 1, random), w2)
+
       val outWidth = IntWidth(BigInt(baseWidth, random))
       val outWidthType = UIntType(outWidth)
 
+      println(f"sintvalue ${i1.value}%x * sintvalue ${i2.value}%x $i1 $i2")
+
       val out = evaluator.mathPrimitive(MUL_OP, Seq(i1, i2), outWidthType )
 
-//      println(s"$i1 * $i2 => $out")
+      println(s"$i1 * $i2 => $out")
       out.value should be (i1.value * i2.value)
     }
   }
 
-  behavior of "requiredBits"
+  behavior of "requiredBitsForUInt"
 
   it should "return the right amount" in {
-    requiredBits(BigInt("1"*29, 2)) should be (29)
+    requiredBitsForUInt(BigInt("1"*29, 2)) should be (29)
     for( width <- 1 to 100) {
       val num = Big1 << (width - 1)
-      val computed = requiredBits(num)
+      val computed = requiredBitsForUInt(num)
       computed should be (width)
 
       val maxNum = BigInt("1"*width, 2)
-      val maxComputed = requiredBits(maxNum)
+      val maxComputed = requiredBitsForUInt(maxNum)
 //      println(s"width $width computed $maxComputed num $maxNum")
       maxComputed should be (width)
     }
@@ -150,7 +150,8 @@ class LoFirrtlExpressionEvaluatorSpec extends FlatSpec with Matchers {
       for (samples <- 0 to 10) {
         val number = BigInt(maskSize + 10, random)
         val masked = evaluator.mask(number, maskSize)
-//        println(s"mask $maskSize sample number $samples number $number power $power masked $masked calc ${number % power} ")
+        // println(s"mask $maskSize sample number $samples number $number " +
+        //  s"power $power masked $masked calc ${number % power} ")
         masked should be(number % power)
       }
       if(maskSize > 0 ) power <<= 1
@@ -175,8 +176,8 @@ class LoFirrtlExpressionEvaluatorSpec extends FlatSpec with Matchers {
       val num = BigInt("1"*width, 2)
       val shiftedNum = num << shift
       val target = UIntValue(shiftedNum, IntWidth(width + shift))
-      requiredBits(num) should be (width)
-      requiredBits(shiftedNum) should be (width + shift)
+      requiredBitsForUInt(num) should be (width)
+      requiredBitsForUInt(shiftedNum) should be (width + shift)
 
 //      println(s"width $width => num $num arg $shift, target $target result NA")
       val result = evaluator.bitOps(SHIFT_RIGHT_OP, Seq(target), Seq(shift), UIntType(IntWidth(width)))
@@ -193,7 +194,7 @@ class LoFirrtlExpressionEvaluatorSpec extends FlatSpec with Matchers {
         val num = BigInt("1"*i, 2)
         val target = SIntValue(evaluator.shiftLeft(num, arg), IntWidth(i + arg + 1))
 
-        val result = evaluator.bitOps(SHIFT_RIGHT_OP, Seq(target), Seq(arg), SIntType(IntWidth(i+1)))
+        val result = evaluator.bitOps(SHIFT_RIGHT_OP, Seq(target), Seq(arg), SIntType(IntWidth(i + 1)))
         //        println(s"num $num arg $arg, target $target result $result")
         result.value should be (num)
       }
@@ -201,7 +202,7 @@ class LoFirrtlExpressionEvaluatorSpec extends FlatSpec with Matchers {
         val num = -BigInt("1"*i, 2)
         val target = SIntValue(evaluator.shiftLeft(num, arg), IntWidth(i + arg + 1))
 
-        val result = evaluator.bitOps(SHIFT_RIGHT_OP, Seq(target), Seq(arg), SIntType(IntWidth(i+1)))
+        val result = evaluator.bitOps(SHIFT_RIGHT_OP, Seq(target), Seq(arg), SIntType(IntWidth(i + 1)))
         //        println(s"num $num arg $arg, target $target result $result")
         result.value should be (num)
       }
@@ -222,20 +223,20 @@ class LoFirrtlExpressionEvaluatorSpec extends FlatSpec with Matchers {
         val target = UIntValue(num, IntWidth(i))
         val testTarget = evaluator.shiftLeft(num, arg)
 
-        val result = evaluator.bitOps(SHIFT_LEFT_OP, Seq(target), Seq(arg), UIntType(IntWidth(i+arg)))
-        //        println(s"num $num arg $arg, target $target result $result")
+        val result = evaluator.bitOps(SHIFT_LEFT_OP, Seq(target), Seq(arg), UIntType(IntWidth(i + arg)))
+        // println(s"num $num arg $arg, target $target result $result")
         result.value should be (testTarget)
-        result.width should be (i+arg)
+        result.width should be (i + arg)
       }
       for(arg <- 1 until 50) {
-        val num = BigInt("1"*i, 2)
-        val target = SIntValue(num, IntWidth(i))
+        val num = BigInt("1" * i, 2)
+        val target = SIntValue(num, IntWidth(i + 1))
         val testTarget = evaluator.shiftLeft(num, arg)
 
-        val result = evaluator.bitOps(SHIFT_LEFT_OP, Seq(target), Seq(arg), SIntType(IntWidth(i+arg)))
-        //        println(s"num $num arg $arg, target $target result $result")
+        val result = evaluator.bitOps(SHIFT_LEFT_OP, Seq(target), Seq(arg), SIntType(IntWidth(i + arg)))
+        // println(f"num $num%x arg $arg, target $target result ${result.value}%x.S<${result.width}>")
         result.value should be (testTarget)
-        result.width should be (i+arg)
+        result.width should be (i + arg + 1)
       }
     }
   }
@@ -257,8 +258,8 @@ class LoFirrtlExpressionEvaluatorSpec extends FlatSpec with Matchers {
       val num = BigInt("1"*width, 2)
       val shiftedNum = num << shift
       val target = UIntValue(shiftedNum, IntWidth(width + shift))
-      requiredBits(num) should be (width)
-      requiredBits(shiftedNum) should be (width + shift)
+      requiredBitsForUInt(num) should be (width)
+      requiredBitsForUInt(shiftedNum) should be (width + shift)
 
 //      println(s"width $width => num $num arg $shift, target $target result NA")
       val result = evaluator.bitOps(SHIFT_RIGHT_OP, Seq(target), Seq(shift), UIntType(IntWidth(width)))
@@ -275,7 +276,7 @@ class LoFirrtlExpressionEvaluatorSpec extends FlatSpec with Matchers {
         val num = BigInt("1"*i, 2)
         val target = SIntValue(evaluator.shiftLeft(num, arg), IntWidth(i + arg + 1))
 
-        val result = evaluator.bitOps(SHIFT_RIGHT_OP, Seq(target), Seq(arg), SIntType(IntWidth(i+1)))
+        val result = evaluator.bitOps(SHIFT_RIGHT_OP, Seq(target), Seq(arg), SIntType(IntWidth(i + 1)))
         //        println(s"num $num arg $arg, target $target result $result")
         result.value should be (num)
       }
@@ -283,7 +284,7 @@ class LoFirrtlExpressionEvaluatorSpec extends FlatSpec with Matchers {
         val num = -BigInt("1"*i, 2)
         val target = SIntValue(evaluator.shiftLeft(num, arg), IntWidth(i + arg + 1))
 
-        val result = evaluator.bitOps(SHIFT_RIGHT_OP, Seq(target), Seq(arg), SIntType(IntWidth(i+1)))
+        val result = evaluator.bitOps(SHIFT_RIGHT_OP, Seq(target), Seq(arg), SIntType(IntWidth(i + 1)))
         //        println(s"num $num arg $arg, target $target result $result")
         result.value should be (num)
       }
@@ -295,21 +296,23 @@ class LoFirrtlExpressionEvaluatorSpec extends FlatSpec with Matchers {
         val testTarget = evaluator.shiftLeft(num, arg)
         val shiftValue = evaluator.makeUIntValue(arg, IntWidth(req_num_bits(arg)))
 
-        val result = evaluator.dynamicBitOps(DYN_SHIFT_LEFT_OP, Seq(target, shiftValue), Seq(), UIntType(IntWidth(i+arg)))
+        val result = evaluator.dynamicBitOps(DYN_SHIFT_LEFT_OP, Seq(target, shiftValue),
+          Seq(), UIntType(IntWidth(i + arg)))
         //        println(s"num $num arg $arg, target $target result $result")
         result.value should be (testTarget)
-        result.width should be (i+arg)
+        result.width should be (i + arg)
       }
       for(arg <- 1 until 50) {
         val num = BigInt("1"*i, 2)
-        val target = SIntValue(num, IntWidth(i))
+        val target = SIntValue(num, IntWidth(i + 1))
         val testTarget = evaluator.shiftLeft(num, arg)
         val shiftValue = evaluator.makeUIntValue(arg, IntWidth(req_num_bits(arg)))
 
-        val result = evaluator.dynamicBitOps(DYN_SHIFT_LEFT_OP, Seq(target, shiftValue), Seq(), SIntType(IntWidth(i+arg)))
+        val result = evaluator.dynamicBitOps(DYN_SHIFT_LEFT_OP, Seq(target, shiftValue),
+          Seq(), SIntType(IntWidth(i + arg)))
         //        println(s"num $num arg $arg, target $target result $result")
         result.value should be (testTarget)
-        result.width should be (i+arg)
+        result.width should be (i + arg + 1)
       }
     }
   }
@@ -332,12 +335,13 @@ class LoFirrtlExpressionEvaluatorSpec extends FlatSpec with Matchers {
       val shiftedNum = num >> shift
 
       val target = UIntValue(num, IntWidth(width))
-      val shiftUInt = UIntValue(shift, IntWidth(requiredBits(shift)))
+      val shiftUInt = UIntValue(shift, IntWidth(requiredBitsForUInt(shift)))
 
-      requiredBits(num) should be (width)
-      requiredBits(shiftedNum) should be (width - shift)
+      requiredBitsForUInt(num) should be (width)
+      requiredBitsForUInt(shiftedNum) should be (width - shift)
 
-      val result = evaluator.dynamicBitOps(DYN_SHIFT_RIGHT_OP, Seq(target, shiftUInt), Seq(), UIntType(IntWidth(width)))
+      val result = evaluator.dynamicBitOps(DYN_SHIFT_RIGHT_OP, Seq(target, shiftUInt),
+        Seq(), UIntType(IntWidth(width)))
 //      println(s"width $width => num $num arg $shift, target $target result $result")
       result.value should be (shiftedNum)
     }

--- a/src/test/scala/firrtl_interpreter/TestUtils.scala
+++ b/src/test/scala/firrtl_interpreter/TestUtils.scala
@@ -175,6 +175,11 @@ object IntWidthTestValuesGenerator {
 }
 
 object BigIntTestValuesGenerator {
+  def apply(extrema: (BigInt, BigInt)): BigIntTestValuesGenerator = {
+    val gen = new BigIntTestValuesGenerator(extrema._1, extrema._2)
+
+    gen
+  }
   def apply(minValue: BigInt, maxValue: BigInt): BigIntTestValuesGenerator = {
     val gen = new BigIntTestValuesGenerator(minValue, maxValue)
 


### PR DESCRIPTION
ConcreteSInt toString now show S
Added casting test
Found and fixed size bug on SInt - UInt width now max(w1,w2)+2
Better Binary string maker for ConcreteSInt
Re-work figuring how big many bits required for a number to fit in a Concrete UInt or SInt
New Tests for casting
Make main branch depend on development firrtl
script to start repl "frepl.sh"
More changes for SInt width fixes
replace requiredBits with specific versions for UInt and SInt
Some style cleanup
Fixed tests with erroneous notions of SInt width (usually did not take into account positive value needs extra bit for zero sign bit)