### PR TITLE
Fixed and, or, xor operations when applied to negative SInts

### DIFF
--- a/src/main/scala/firrtl_interpreter/Concrete.scala
+++ b/src/main/scala/firrtl_interpreter/Concrete.scala
@@ -179,11 +179,17 @@ trait Concrete {
       if(v >= 0) flipped = flipped.setBit(width-1) // invert sign and stick at high end
       ConcreteUInt(flipped, width)
   }
-  def &(that: Concrete): ConcreteUInt = ConcreteUInt(this.value & that.value, width.max(that.width))
-  def |(that: Concrete): ConcreteUInt = ConcreteUInt(this.value | that.value, width.max(that.width))
-  def ^(that: Concrete): ConcreteUInt = ConcreteUInt(this.value ^ that.value, width.max(that.width))
+  def &(that: Concrete): ConcreteUInt = {
+    ConcreteUInt(this.asUInt.value & that.asUInt.value, width.max(that.width))
+  }
+  def |(that: Concrete): ConcreteUInt = {
+    ConcreteUInt(this.asUInt.value | that.asUInt.value, width.max(that.width))
+  }
+  def ^(that: Concrete): ConcreteUInt = {
+    ConcreteUInt(this.asUInt.value ^ that.asUInt.value, width.max(that.width))
+  }
   def cat(that: Concrete): ConcreteUInt = {
-    ConcreteUInt((this.value.abs << that.width) + that.value, this.width + that.width)
+    ConcreteUInt((this.asUInt.value << that.width) + that.asUInt.value, this.width + that.width)
   }
   // extraction
   def getBits(hi: Int, lo: Int): BigInt = {
@@ -301,6 +307,9 @@ object Concrete {
 case class ConcreteUInt(val value: BigInt, val width: Int) extends Concrete {
   if(width < 0) {
     throw new InterpreterException(s"error: ConcreteUInt($value, $width) bad width $width must be > 0")
+  }
+  if(value < 0) {
+    throw new InterpreterException(s"error: ConcreteUInt($value, $width) value $value must be > 0")
   }
   val bitsRequired = requiredBitsForUInt(value)
   if((width > 0) && (bitsRequired > width)) {

--- a/src/test/scala/firrtl_interpreter/ConcreteSpec.scala
+++ b/src/test/scala/firrtl_interpreter/ConcreteSpec.scala
@@ -451,4 +451,29 @@ class ConcreteSpec extends FlatSpec with Matchers {
     }
     ConcreteSInt(BigInt(randomWidth, random) * sign, width)
   }
+
+  behavior of "UInt with negative values"
+
+  it should "not allow negative inputs" in {
+    intercept[InterpreterException] {
+      ConcreteUInt(-1, 4)
+    }
+  }
+
+  it should "not be possible to create a negative UInt from various operations" in {
+    val a = ConcreteSInt(-1, 6)
+    val b = ConcreteSInt(-1, 6)
+    val z = ConcreteSInt(0, 6)
+    val c = a & b
+    c.value should be (BigInt("111111", 2))
+
+    val d = a | z
+    d.value should be (BigInt("111111", 2))
+
+    val e = a ^ z
+    e.value should be (BigInt("111111", 2))
+
+    val f = a.cat(b)
+    f.value should be (BigInt("1"*12, 2))
+  }
 }


### PR DESCRIPTION
This fixes issue #23 
It is necessary to convert to UInt before applying the operations