### PR TITLE
Refactor poison values so they propagate correctly through interpreter

### DIFF
--- a/src/main/scala/firrtl_interpreter/Concrete.scala
+++ b/src/main/scala/firrtl_interpreter/Concrete.scala
@@ -9,63 +9,67 @@ trait Concrete {
   val width : Int
   val lowBitOffset = 0
 
+  def poisoned: Boolean
+  def poisonString: String = if(poisoned) "P" else ""
+  def poison(p1: Boolean, p2: Boolean) : Boolean = p1 || p2
+
   def +(that: Concrete): Concrete = {
     (this, that) match {
-      case (ConcreteUInt(v1, w1), ConcreteUInt(v2, w2)) => ConcreteUInt(v1 + v2, w1.max(w2) + 1)
-      case (ConcreteUInt(v1, w1), ConcreteSInt(v2, w2)) => ConcreteSInt(v1 + v2, w1.max(w2) + 1)
-      case (ConcreteSInt(v1, w1), ConcreteUInt(v2, w2)) => ConcreteSInt(v1 + v2, w1.max(w2) + 1)
-      case (ConcreteSInt(v1, w1), ConcreteSInt(v2, w2)) => ConcreteSInt(v1 + v2, w1.max(w2) + 1)
+      case (ConcreteUInt(v1, w1, p1), ConcreteUInt(v2, w2, p2)) => ConcreteUInt(v1 + v2, w1.max(w2) + 1, poison(p1, p2))
+      case (ConcreteUInt(v1, w1, p1), ConcreteSInt(v2, w2, p2)) => ConcreteSInt(v1 + v2, w1.max(w2) + 1, poison(p1, p2))
+      case (ConcreteSInt(v1, w1, p1), ConcreteUInt(v2, w2, p2)) => ConcreteSInt(v1 + v2, w1.max(w2) + 1, poison(p1, p2))
+      case (ConcreteSInt(v1, w1, p1), ConcreteSInt(v2, w2, p2)) => ConcreteSInt(v1 + v2, w1.max(w2) + 1, poison(p1, p2))
     }
   }
   def -(that: Concrete): Concrete = {
     (this, that) match {
-      case (ConcreteUInt(v1, w1), ConcreteUInt(v2, w2)) => ConcreteSInt(v1 - v2, w1.max(w2) + 1)
-      case (ConcreteUInt(v1, w1), ConcreteSInt(v2, w2)) =>
+      case (ConcreteUInt(v1, w1, p1), ConcreteUInt(v2, w2, p2)) => ConcreteSInt(v1 - v2, w1.max(w2) + 1, poison(p1, p2))
+      case (ConcreteUInt(v1, w1, p1), ConcreteSInt(v2, w2, p2)) =>
         val newWidth = (w1 + 2).max(w2 + 1)
-        ConcreteSInt(v1 - v2, newWidth)
-      case (ConcreteSInt(v1, w1), ConcreteUInt(v2, w2)) =>
+        ConcreteSInt(v1 - v2, newWidth, poison(p1, p2))
+      case (ConcreteSInt(v1, w1, p1), ConcreteUInt(v2, w2, p2)) =>
         val newWidth = if(w1 == 1) w2 + 1 else (w1 + 1).max(w2 + 2)
-        ConcreteSInt(v1 - v2, newWidth)
-      case (ConcreteSInt(v1, w1), ConcreteSInt(v2, w2)) => ConcreteSInt(v1 - v2, w1.max(w2) + 1)
+        ConcreteSInt(v1 - v2, newWidth, poison(p1, p2))
+      case (ConcreteSInt(v1, w1, p1), ConcreteSInt(v2, w2, p2)) => ConcreteSInt(v1 - v2, w1.max(w2) + 1, poison(p1, p2))
     }
   }
   def *(that: Concrete): Concrete = {
     (this, that) match {
-      case (ConcreteUInt(v1, w1), ConcreteUInt(v2, w2)) => ConcreteUInt(v1 * v2, w1 + w2)
-      case (ConcreteUInt(v1, w1), ConcreteSInt(v2, w2)) => ConcreteSInt(v1 * v2, w1 + w2)
-      case (ConcreteSInt(v1, w1), ConcreteUInt(v2, w2)) => ConcreteSInt(v1 * v2, w1 + w2)
-      case (ConcreteSInt(v1, w1), ConcreteSInt(v2, w2)) => ConcreteSInt(v1 * v2, w1 + w2)
+      case (ConcreteUInt(v1, w1, p1), ConcreteUInt(v2, w2, p2)) => ConcreteUInt(v1 * v2, w1 + w2, poison(p1, p2))
+      case (ConcreteUInt(v1, w1, p1), ConcreteSInt(v2, w2, p2)) => ConcreteSInt(v1 * v2, w1 + w2, poison(p1, p2))
+      case (ConcreteSInt(v1, w1, p1), ConcreteUInt(v2, w2, p2)) => ConcreteSInt(v1 * v2, w1 + w2, poison(p1, p2))
+      case (ConcreteSInt(v1, w1, p1), ConcreteSInt(v2, w2, p2)) => ConcreteSInt(v1 * v2, w1 + w2, poison(p1, p2))
     }
   }
   def /(that: Concrete): Concrete = {
     (this, that) match {
-      case (ConcreteUInt(v1, w1), ConcreteUInt(v2, w2)) =>
-        if(that.value == BigInt(0)) { PoisonedUInt(w1) }
+      case (ConcreteUInt(v1, w1, p1), ConcreteUInt(v2, w2, p2)) =>
+        if(that.value == BigInt(0)) { Concrete.poisonedUInt(w1) }
         else { ConcreteUInt(v1 / v2, w1) }
-      case (ConcreteUInt(v1, w1), ConcreteSInt(v2, w2)) =>
-        if(that.value == BigInt(0)) { PoisonedSInt(w1) }
+      case (ConcreteUInt(v1, w1, p1), ConcreteSInt(v2, w2, p2)) =>
+        if(that.value == BigInt(0)) { Concrete.poisonedSInt(w1) }
         else { ConcreteSInt(v1 / v2, w1 + 1) }
-      case (ConcreteSInt(v1, w1), ConcreteUInt(v2, w2)) =>
-        if(that.value == BigInt(0)) { PoisonedSInt(w1) }
+      case (ConcreteSInt(v1, w1, p1), ConcreteUInt(v2, w2, p2)) =>
+        if(that.value == BigInt(0)) { Concrete.poisonedSInt(w1) }
         else { ConcreteSInt(v1 / v2, w1) }
-      case (ConcreteSInt(v1, w1), ConcreteSInt(v2, w2)) =>
-        if(that.value == BigInt(0)) { PoisonedSInt(w1) }
+      case (ConcreteSInt(v1, w1, p1), ConcreteSInt(v2, w2, p2)) =>
+        if(that.value == BigInt(0)) { Concrete.poisonedSInt(w1) }
         else { ConcreteSInt(v1 / v2, w1 + 1) }
     }
   }
   def %(that: Concrete): Concrete = {
     (this, that) match {
-      case (ConcreteUInt(v1, w1), ConcreteUInt(v2, w2)) =>
-        if(that.value == BigInt(0)) { PoisonedUInt(w1.min(w2)) }
+      case (ConcreteUInt(v1, w1, _), ConcreteUInt(v2, w2, _)) =>
+        if(that.value == BigInt(0)) { Concrete.poisonedUInt(w1.min(w2)) }
         else { ConcreteUInt(v1 % v2, w1.min(w2)) }
-      case (ConcreteUInt(v1, w1), ConcreteSInt(v2, w2)) =>
-        if(that.value == BigInt(0)) { PoisonedUInt(w1.min(w2)) }
+      case (ConcreteUInt(v1, w1, _), ConcreteSInt(v2, w2, _)) =>
+        if(that.value == BigInt(0)) { Concrete.poisonedUInt(w1.min(w2)) }
         else { ConcreteUInt(v1 % v2, w1.min(w2)) }
-      case (ConcreteSInt(v1, w1), ConcreteUInt(v2, w2)) =>
-        if(that.value == BigInt(0)) { PoisonedSInt(w1.min(w2 + 1)) }
+      case (ConcreteSInt(v1, w1, _), ConcreteUInt(v2, w2, _)) =>
+        if(that.value == BigInt(0)) { Concrete.poisonedSInt(w1.min(w2 + 1)) }
         else { ConcreteSInt(v1 % v2, w1.min(w2 + 1)) }
-      case (ConcreteSInt(v1, w1), ConcreteSInt(v2, w2)) =>
-        if(that.value == BigInt(0)) { PoisonedSInt(w1.min(w2)) }
+      case (ConcreteSInt(v1, w1, _), ConcreteSInt(v2, w2, _)) =>
+        if(that.value == BigInt(0)) { Concrete.poisonedSInt(w1.min(w2)) }
         else { ConcreteSInt(v1 % v2, w1.min(w2)) }
     }
   }
@@ -81,21 +85,21 @@ trait Concrete {
   // Padding
   def pad(n: BigInt): Concrete = pad(n.toInt)
   def pad(n: Int): Concrete = this match {
-    case ConcreteUInt(v, w) => ConcreteUInt(this.value, this.width.max(n))
-    case ConcreteSInt(v, w) => ConcreteSInt(this.value, this.width.max(n))
+    case ConcreteUInt(v, w, p) => ConcreteUInt(this.value, this.width.max(n), p)
+    case ConcreteSInt(v, w, p) => ConcreteSInt(this.value, this.width.max(n), p)
   }
   // Casting     TODO: I don't think this is done right, need to look at top bit each way
   def asUInt: ConcreteUInt = {
     this match {
       case si: ConcreteSInt => tail(0)
-      case _ => ConcreteUInt(this.value, this.width)
+      case _ => ConcreteUInt(this.value, this.width, this.poisoned)
     }
   }
   def asSInt: ConcreteSInt = {
     this match {
-      case ConcreteSInt(previousValue, previousWidth) =>
-        ConcreteSInt(previousValue, previousWidth)
-      case ConcreteUInt(previousValue, previousWidth) =>
+      case ConcreteSInt(previousValue, previousWidth, p) =>
+        ConcreteSInt(previousValue, previousWidth, p)
+      case ConcreteUInt(previousValue, previousWidth, p) =>
         val newValue = {
           if(previousValue == Big1 && previousWidth == 1) {
             BigInt(-1)
@@ -111,13 +115,13 @@ trait Concrete {
             }
           }
         }
-        ConcreteSInt(newValue, this.width)
+        ConcreteSInt(newValue, this.width, p)
     }
   }
   def asClock: ConcreteClock = ConcreteClock(boolToBigInt((this.value & BigInt(1)) > BigInt(0)))
   // Shifting
   def <<(that: Concrete): Concrete = that match {
-    case ConcreteUInt(thisValue, _) =>
+    case ConcreteUInt(thisValue, _, _) =>
       assert(thisValue >= 0, s"ERROR:$this << $that ${that.value} must be >= 0")
       <<(that.value)
     case _ => throw new InterpreterException(s"Cannot shift $this << $that where $that is not a UInt parameter")
@@ -126,20 +130,20 @@ trait Concrete {
     val shift = that.value.toInt
     assert(that.value >= 0, s"ERROR:$this << $that ${that.value} must be >= 0")
     this match {
-      case ConcreteUInt(thisValue, thisWidth) => ConcreteUInt(this.value << shift, thisWidth + shift)
-      case ConcreteSInt(thisValue, thisWidth) => ConcreteSInt(this.value << shift, thisWidth + shift)
+      case ConcreteUInt(thisValue, thisWidth, p) => ConcreteUInt(this.value << shift, thisWidth + shift, p)
+      case ConcreteSInt(thisValue, thisWidth, p) => ConcreteSInt(this.value << shift, thisWidth + shift, p)
     }
   }
   def <<(that: BigInt): Concrete = <<(that.toInt)
   def <<(shift: Int): Concrete = {
     assert(shift >= 0, s"ERROR:$this << $shift $shift must be >= 0")
     this match {
-      case ConcreteUInt(thisValue, thisWidth) => ConcreteUInt(this.value << shift, thisWidth + shift)
-      case ConcreteSInt(thisValue, thisWidth) => ConcreteSInt(this.value << shift, thisWidth + shift)
+      case ConcreteUInt(thisValue, thisWidth, p) => ConcreteUInt(this.value << shift, thisWidth + shift, p)
+      case ConcreteSInt(thisValue, thisWidth, p) => ConcreteSInt(this.value << shift, thisWidth + shift, p)
     }
   }
   def >>(that: Concrete): Concrete = that match {
-    case ConcreteUInt(thatValue, _) =>
+    case ConcreteUInt(thatValue, _, _) =>
       val shift = thatValue.toInt
       assert(shift >= 0, s"ERROR:$this >> $that ${that.value} must be >= 0")
       assert(shift < this.width, s"ERROR:$this >> $that ${that.value} must be > ${this.width}")
@@ -151,64 +155,66 @@ trait Concrete {
     assert(shift >= 0, s"ERROR:$this >> $shift $shift must be >= 0")
     assert(shift < this.width, s"ERROR:$this >> $shift $shift must be >= 0")
     this match {
-      case ConcreteUInt(thisValue, thisWidth) => ConcreteUInt(this.value >> shift, thisWidth - shift)
-      case ConcreteSInt(thisValue, thisWidth) => ConcreteSInt(this.value >> shift, thisWidth - shift)
+      case ConcreteUInt(thisValue, thisWidth, p) => ConcreteUInt(this.value >> shift, thisWidth - shift, p)
+      case ConcreteSInt(thisValue, thisWidth, p) => ConcreteSInt(this.value >> shift, thisWidth - shift, p)
     }
   }
   // Signed
   def cvt: ConcreteSInt = this match {
-    case ConcreteUInt(thisValue, thisWidth) => ConcreteSInt(thisValue, thisWidth + 1)
-    case ConcreteSInt(thisValue, thisWidth) => ConcreteSInt(thisValue, thisWidth)
+    case ConcreteUInt(thisValue, thisWidth, p) => ConcreteSInt(thisValue, thisWidth + 1, p)
+    case ConcreteSInt(thisValue, thisWidth, p) => ConcreteSInt(thisValue, thisWidth, p)
   }
   def neg: ConcreteSInt = {
     //TODO: Is this right?
     ConcreteSInt(-value, width + 1)
   }
   def not: ConcreteUInt = this match {
-    case ConcreteUInt(v, _) =>
+    case ConcreteUInt(v, _, p) =>
       var flipped = value
       for(bitIndex <- 0 until width) {
         flipped = flipped.flipBit(bitIndex)
       }
-      ConcreteUInt(flipped, width)
-    case ConcreteSInt(v, _) =>
+      ConcreteUInt(flipped, width, p)
+    case ConcreteSInt(v, _, p) =>
       var flipped = value.abs
       for(bitIndex <- 0 until width-1) {
         flipped = flipped.flipBit(bitIndex)
       }
       if(v >= 0) flipped = flipped.setBit(width-1) // invert sign and stick at high end
-      ConcreteUInt(flipped, width)
+      ConcreteUInt(flipped, width, p)
   }
   def &(that: Concrete): ConcreteUInt = {
-    ConcreteUInt(this.asUInt.value & that.asUInt.value, width.max(that.width))
+    ConcreteUInt(this.asUInt.value & that.asUInt.value, width.max(that.width), poison(this.poisoned, that.poisoned))
   }
   def |(that: Concrete): ConcreteUInt = {
-    ConcreteUInt(this.asUInt.value | that.asUInt.value, width.max(that.width))
+    ConcreteUInt(this.asUInt.value | that.asUInt.value, width.max(that.width), poison(this.poisoned, that.poisoned))
   }
   def ^(that: Concrete): ConcreteUInt = {
-    ConcreteUInt(this.asUInt.value ^ that.asUInt.value, width.max(that.width))
+    ConcreteUInt(this.asUInt.value ^ that.asUInt.value, width.max(that.width), poison(this.poisoned, that.poisoned))
   }
   def cat(that: Concrete): ConcreteUInt = {
-    ConcreteUInt((this.asUInt.value << that.width) + that.asUInt.value, this.width + that.width)
+    ConcreteUInt((this.asUInt.value << that.width) + that.asUInt.value, this.width + that.width,
+      poison(this.poisoned, that.poisoned))
   }
   // extraction
   def getBits(hi: Int, lo: Int): BigInt = {
+    val uint = this.asUInt
     val desiredNumberOfBits = (hi - lo) + 1
-    val bottomRemoved = value >> lo
+    val bottomRemoved = uint.value >> lo
     val modulus = Big1 << desiredNumberOfBits
     val topRemoved = bottomRemoved % modulus
     topRemoved
   }
 //  def bits(hi: BigInt, lo: BigInt): ConcreteUInt = bits(hi.toInt, lo.toInt)
   def bits(hi: BigInt, lo: BigInt): Concrete = {
-  assert(lo >= Big0, s"Error:Bits($this, hi=$hi, lo=$lo) lo must be >= 0")
-  assert(lo <= width, s"Error:Bits($this, hi=$hi, lo=$lo) lo must be < ${this.width}")
-  assert(hi >= lo,   s"Error:Bits($this, hi=$hi, lo=$lo) hi must be >= $lo")
-  assert(hi <= width, s"Error:Bits($this, hi=$hi, lo=$lo) hi must be < ${this.width}")
+    assert(lo >= Big0, s"Error:Bits($this, hi=$hi, lo=$lo) lo must be >= 0")
+    assert(lo <= width, s"Error:Bits($this, hi=$hi, lo=$lo) lo must be < ${this.width}")
+    assert(hi >= lo,   s"Error:Bits($this, hi=$hi, lo=$lo) hi must be >= $lo")
+    assert(hi <= width, s"Error:Bits($this, hi=$hi, lo=$lo) hi must be < ${this.width}")
     val (high, low) = (hi.toInt, lo.toInt)
     this match {
-      case ConcreteUInt(v, _) => ConcreteUInt(getBits(high, low), high - low + 1)
-      case ConcreteSInt(v, _) => ConcreteSInt(getBits(high, low), high - low + 1)
+      case ConcreteUInt(v, _, p) => ConcreteUInt(getBits(high, low), high - low + 1, p)
+      case ConcreteSInt(v, _, p) => ConcreteUInt(getBits(high, low), high - low + 1, p)
     }
   }
   def head(n: BigInt): Concrete = {
@@ -229,31 +235,31 @@ trait Concrete {
       for(i <- 0 until bitsWanted) {
         if(value.testBit(i)) x = x.setBit(i)
       }
-      ConcreteUInt(x, bitsWanted)
+      ConcreteUInt(x, bitsWanted, this.poisoned)
 //    }
   }
 
   def andReduce: Concrete = this match {
-    case ConcreteUInt(v, w) =>
-      ConcreteUInt(boolToBigInt((0 until w).map(i => v.testBit(i)).reduce(_&&_)), 1)
-    case ConcreteSInt(v, w) =>
-      ConcreteUInt(boolToBigInt((0 until w-1).map(i => v.testBit(i)).reduce(_&&_) && (w < Big0)), 1)
+    case ConcreteUInt(v, w, p) =>
+      ConcreteUInt(boolToBigInt((0 until w).map(i => v.testBit(i)).reduce(_&&_)), 1, p)
+    case ConcreteSInt(v, w, p) =>
+      ConcreteUInt(boolToBigInt((0 until w-1).map(i => v.testBit(i)).reduce(_&&_) && (w < Big0)), 1, p)
     case ConcreteClock(v) =>
       ConcreteUInt(boolToBigInt(v.testBit(0)), 1)
   }
   def orReduce: Concrete = this match {
-    case ConcreteUInt(v, w) =>
-      ConcreteUInt(boolToBigInt((0 until w).map(i => v.testBit(i)).reduce(_||_)), 1)
-    case ConcreteSInt(v, w) =>
-      ConcreteUInt(boolToBigInt((0 until w-1).map(i => v.testBit(i)).reduce(_||_) || (w < Big0)), 1)
+    case ConcreteUInt(v, w, p) =>
+      ConcreteUInt(boolToBigInt((0 until w).map(i => v.testBit(i)).reduce(_||_)), 1, p)
+    case ConcreteSInt(v, w, p) =>
+      ConcreteUInt(boolToBigInt((0 until w-1).map(i => v.testBit(i)).reduce(_||_) || (w < Big0)), 1, p)
     case ConcreteClock(v) =>
       ConcreteUInt(boolToBigInt(v.testBit(0)), 1)
   }
   def xorReduce: Concrete = this match {
-    case ConcreteUInt(v, w) =>
-      ConcreteUInt(boolToBigInt((0 until w).map(i => v.testBit(i)).reduce(_^_)), 1)
-    case ConcreteSInt(v, w) =>
-      ConcreteUInt(boolToBigInt((0 until w-1).map(i => v.testBit(i)).reduce(_^_) ^ (w < Big0)), 1)
+    case ConcreteUInt(v, w, p) =>
+      ConcreteUInt(boolToBigInt((0 until w).map(i => v.testBit(i)).reduce(_^_)), 1, p)
+    case ConcreteSInt(v, w, p) =>
+      ConcreteUInt(boolToBigInt((0 until w-1).map(i => v.testBit(i)).reduce(_^_) ^ (w < Big0)), 1, p)
     case ConcreteClock(v) =>
       ConcreteUInt(boolToBigInt(! v.testBit(0)), 1)
   }
@@ -263,13 +269,12 @@ trait Concrete {
     val bitString = value.abs.toString(2)
 
     this match {
-      case ConcreteUInt(v, w) =>
-        s"UInt<$width>${"0"*(width-bitString.length)}$bitString"
-      case ConcreteSInt(v, w) =>
-        s"SInt<$width>${if(v<0)"1" else "0"}${"0"*((width-1)-bitString.length)}$bitString"
+      case ConcreteUInt(v, w, p) =>
+        s"${poisonString}UInt<$width>${"0"*(width-bitString.length)}$bitString"
+      case ConcreteSInt(v, w, p) =>
+        s"${poisonString}SInt<$width>${if(v<0)"1" else "0"}${"0"*((width-1)-bitString.length)}$bitString"
     }
   }
-  def poisoned: Boolean = false
 }
 object Concrete {
   def apply(u: UIntLiteral): ConcreteUInt = {
@@ -287,13 +292,18 @@ object Concrete {
       case ClockType                 => ConcreteClock(value)
     }
   }
-  def randomUInt(width: Int): ConcreteUInt  = ConcreteUInt(randomBigInt(width), width)
-  def randomSInt(width: Int): ConcreteSInt  = {
+  def poisonedUInt(width: Int): ConcreteUInt = randomUInt(width, poisoned = true)
+  def poisonedSInt(width: Int): ConcreteSInt = randomSInt(width, poisoned = true)
+
+  def randomUInt(width: Int, poisoned: Boolean = false): ConcreteUInt  = {
+    ConcreteUInt(randomBigInt(width), width, poisoned)
+  }
+  def randomSInt(width: Int, poisoned: Boolean = false): ConcreteSInt  = {
     val (low, high) = extremaOfSIntOfWidth(width)
     val randomValue = randomBigInt(width)
     val positiveRandom = randomValue % ((high - low) + 1)
 
-    ConcreteSInt(positiveRandom + low, width)
+    ConcreteSInt(positiveRandom + low, width, poisoned)
   }
   def randomClock():          ConcreteClock = ConcreteClock(randomBigInt(1))
 }
@@ -304,12 +314,12 @@ object Concrete {
   * @param value the BigInt value of this UInt, must be non-negative
   * @param width the number of bits in this value, must be big enough to contain value
   */
-case class ConcreteUInt(val value: BigInt, val width: Int) extends Concrete {
+case class ConcreteUInt(val value: BigInt, val width: Int, poisoned: Boolean = false) extends Concrete {
   if(width < 0) {
     throw new InterpreterException(s"error: ConcreteUInt($value, $width) bad width $width must be > 0")
   }
   if(value < 0) {
-    throw new InterpreterException(s"error: ConcreteUInt($value, $width) value $value must be > 0")
+    throw new InterpreterException(s"error: ConcreteUInt($value, $width) bad value $value must be >= 0")
   }
   val bitsRequired = requiredBitsForUInt(value)
   if((width > 0) && (bitsRequired > width)) {
@@ -321,7 +331,7 @@ case class ConcreteUInt(val value: BigInt, val width: Int) extends Concrete {
     if(newWidth == width) this else ConcreteUInt(this.value, newWidth)
   }
   def forceWidth(tpe: Type): ConcreteUInt = forceWidth(typeToWidth(tpe))
-  override def toString: String = s"$value.U<$width>"
+  override def toString: String = s"$value.${poisonString}U<$width>"
 }
 /**
   * A runtime instance of a SInt
@@ -329,7 +339,7 @@ case class ConcreteUInt(val value: BigInt, val width: Int) extends Concrete {
   * @param value the BigInt value of this UInt,
   * @param width the number of bits in this value, must be big enough to contain value plus 1 for sign bit
   */
-case class ConcreteSInt(val value: BigInt, val width: Int) extends Concrete {
+case class ConcreteSInt(val value: BigInt, val width: Int, poisoned: Boolean = false) extends Concrete {
   if(width < 0) {
     throw new InterpreterException(s"error: ConcreteSInt($value, $width) bad width $width must be > 0")
   }
@@ -351,10 +361,11 @@ case class ConcreteSInt(val value: BigInt, val width: Int) extends Concrete {
     if(newWidth == width) this else ConcreteSInt(this.value, newWidth)
   }
   def forceWidth(tpe: Type): ConcreteSInt = forceWidth(typeToWidth(tpe))
-  override def toString: String = s"$value.S<$width>"
+  override def toString: String = s"$value.${poisonString}S<$width>"
 }
 case class ConcreteClock(val value: BigInt) extends Concrete {
   val width = 1
+  val poisoned = false
 
   def forceWidth(width: Int): ConcreteClock = {
     if(width == 1) { this }
@@ -363,18 +374,28 @@ case class ConcreteClock(val value: BigInt) extends Concrete {
   def forceWidth(tpe: Type): ConcreteClock = forceWidth(typeToWidth(tpe))
 }
 
-case class PoisonedUInt(width: Int) extends Concrete {
-  val value = Big0
-  override def forceWidth(w: Int): PoisonedUInt = PoisonedUInt(w)
-  def forceWidth(tpe: Type): PoisonedUInt = forceWidth(typeToWidth(tpe))
-  override def poisoned: Boolean = true
-}
-case class PoisonedSInt(width: Int) extends Concrete {
-  val value = Big0
-  override def forceWidth(w: Int): PoisonedSInt = PoisonedSInt(w)
-  def forceWidth(tpe: Type): PoisonedSInt = forceWidth(typeToWidth(tpe))
-  override def poisoned: Boolean = true
-}
+//object PoisonedSInt {
+//  def apply(width: Int): PoisonedSInt = {
+//    new PoisonedSInt(randomBigInt(width), width)
+//  }
+//}
+//object PoisonedUInt {
+//  def apply(width: Int): PoisonedUInt = {
+//    new PoisonedUInt(randomBigInt(width), width)
+//  }
+//}
+//class PoisonedUInt(myValue: BigInt, myWidth: Int) extends ConcreteUInt(myValue, myWidth) {
+//  override def forceWidth(w: Int): PoisonedUInt = new PoisonedUInt(myValue, w)
+//  override def forceWidth(tpe: Type): PoisonedUInt = forceWidth(typeToWidth(tpe))
+//  override def poisoned: Boolean = true
+//  override def toString: String = s"$value.PU<$width>"
+//}
+//class PoisonedSInt(myValue: BigInt, myWidth: Int) extends ConcreteSInt(myValue, myWidth) {
+//  override def forceWidth(w: Int): PoisonedSInt = new PoisonedSInt(value, w)
+//  override def forceWidth(tpe: Type): PoisonedSInt = forceWidth(typeToWidth(tpe))
+//  override def poisoned: Boolean = true
+//  override def toString: String = s"$value.PS<$width>"
+//}
 
 
 

--- a/src/main/scala/firrtl_interpreter/Concrete.scala
+++ b/src/main/scala/firrtl_interpreter/Concrete.scala
@@ -179,11 +179,17 @@ trait Concrete {
       if(v >= 0) flipped = flipped.setBit(width-1) // invert sign and stick at high end
       ConcreteUInt(flipped, width)
   }
-  def &(that: Concrete): ConcreteUInt = ConcreteUInt(this.value & that.value, width.max(that.width))
-  def |(that: Concrete): ConcreteUInt = ConcreteUInt(this.value | that.value, width.max(that.width))
-  def ^(that: Concrete): ConcreteUInt = ConcreteUInt(this.value ^ that.value, width.max(that.width))
+  def &(that: Concrete): ConcreteUInt = {
+    ConcreteUInt(this.asUInt.value & that.asUInt.value, width.max(that.width))
+  }
+  def |(that: Concrete): ConcreteUInt = {
+    ConcreteUInt(this.asUInt.value | that.asUInt.value, width.max(that.width))
+  }
+  def ^(that: Concrete): ConcreteUInt = {
+    ConcreteUInt(this.asUInt.value ^ that.asUInt.value, width.max(that.width))
+  }
   def cat(that: Concrete): ConcreteUInt = {
-    ConcreteUInt((this.value.abs << that.width) + that.value, this.width + that.width)
+    ConcreteUInt((this.asUInt.value << that.width) + that.asUInt.value, this.width + that.width)
   }
   // extraction
   def getBits(hi: Int, lo: Int): BigInt = {
@@ -301,6 +307,9 @@ object Concrete {
 case class ConcreteUInt(val value: BigInt, val width: Int) extends Concrete {
   if(width < 0) {
     throw new InterpreterException(s"error: ConcreteUInt($value, $width) bad width $width must be > 0")
+  }
+  if(value < 0) {
+    throw new InterpreterException(s"error: ConcreteUInt($value, $width) value $value must be > 0")
   }
   val bitsRequired = requiredBitsForUInt(value)
   if((width > 0) && (bitsRequired > width)) {

--- a/src/main/scala/firrtl_interpreter/InterpretiveTester.scala
+++ b/src/main/scala/firrtl_interpreter/InterpretiveTester.scala
@@ -50,6 +50,25 @@ class InterpretiveTester(input: String, vcdOutputFileName: String = "") {
         throw ie
     }
   }
+  /**
+    * Pokes value to the port referenced by string
+    * Warning: pokes to components other than input ports is currently
+    * not supported but does not cause an error warning
+    * This feature should be supported soon
+    *
+    * @param name the name of a port
+    * @param value a value to put on that port
+    */
+  def poke(name: String, value: Concrete): Unit = {
+    try {
+      interpreter.circuitState.setValue(name, value)
+    }
+    catch {
+      case ie: InterpreterException =>
+        println(s"Error: poke($name, $value)")
+        throw ie
+    }
+  }
 
   /** inspect a value of a named circuit component
     *
@@ -58,10 +77,22 @@ class InterpretiveTester(input: String, vcdOutputFileName: String = "") {
     */
   def peek(name: String): BigInt = {
     interpreter.getValue(name) match {
-      case ConcreteUInt(value, _) => value
-      case ConcreteSInt(value, _) => value
+      case ConcreteUInt(value, _, _) => value
+      case ConcreteSInt(value, _, _) => value
       case _ => throw new InterpreterException(s"Error:peek($name) value not found")
-      }
+    }
+  }
+
+  /** inspect a value of a named circuit component
+    *
+    * @param name the name of a circuit component
+    * @return An internal concrete value currently set at name
+    */
+  def peekConcrete(name: String): Concrete = {
+    interpreter.getValue(name) match {
+      case c: Concrete => c
+      case _ => throw new InterpreterException(s"Error:peek($name) value not found")
+    }
   }
 
   /**
@@ -78,8 +109,8 @@ class InterpretiveTester(input: String, vcdOutputFileName: String = "") {
       }
     }
     interpreter.getValue(name) match {
-      case ConcreteUInt (value, _) => testValue(value)
-      case ConcreteSInt(value, _)  => testValue(value)
+      case ConcreteUInt (value, _, _) => testValue(value)
+      case ConcreteSInt(value, _, _)  => testValue(value)
       case _ =>
         throw new InterpreterException(s"Error:expect($name, $expectedValue) value not found")
     }

--- a/src/main/scala/firrtl_interpreter/LoFirrtlExpressionEvaluator.scala
+++ b/src/main/scala/firrtl_interpreter/LoFirrtlExpressionEvaluator.scala
@@ -276,7 +276,7 @@ class LoFirrtlExpressionEvaluator(val dependencyGraph: DependencyGraph, val circ
       expression match {
         case Mux(condition, trueExpression, falseExpression, tpe) =>
           evaluate(condition) match {
-            case ConcreteUInt(value, 1) =>
+            case ConcreteUInt(value, 1, _) =>
               val v = if (value > 0) {
                 if(evaluateAll) { evaluate(falseExpression)}
                 evaluate(trueExpression)
@@ -417,7 +417,7 @@ class LoFirrtlExpressionEvaluator(val dependencyGraph: DependencyGraph, val circ
       }
       else {
         throw new InterpreterException(s"error: don't know what to do with key $key")
-        //      ConcreteUInt(0, 1)
+        //      Concrete.poisonedUInt(1)
       }
     }
 

--- a/src/main/scala/firrtl_interpreter/Memory.scala
+++ b/src/main/scala/firrtl_interpreter/Memory.scala
@@ -141,7 +141,7 @@ class Memory(
     var enable: Boolean     = false
     var clock: Int          = 0
     var address: Int        = 0
-    var data: Concrete      = ConcreteUInt(0, dataWidth)
+    var data: Concrete      = Concrete.poisonedUInt(dataWidth)
 
     def setValue(fieldName: String, concreteValue: Concrete): Unit = {
       fieldName match {
@@ -182,7 +182,7 @@ class Memory(
       override def toString: String = s"[${readPipeLineData.value}]"
     }
     val pipeLine : ArrayBuffer[ReadPipeLineElement] = {
-      ArrayBuffer.fill(latency)(ReadPipeLineElement(ConcreteUInt(0, dataWidth)))
+      ArrayBuffer.fill(latency)(ReadPipeLineElement(Concrete.poisonedUInt(dataWidth)))
     }
 
     override def setValue(fieldName: String, concreteValue: Concrete): Unit = {
@@ -195,16 +195,16 @@ class Memory(
         data = dataStore(address)
       }
       else {
-        pipeLine(0) = ReadPipeLineElement(if(enable) dataStore(address) else PoisonedUInt(dataWidth))
+        pipeLine(0) = ReadPipeLineElement(if(enable) dataStore(address) else Concrete.poisonedUInt(dataWidth))
       }
     }
     def cycle(): Unit = {
       if(latency > 0) {
         data = pipeLine.remove(0).readPipeLineData
-        pipeLine += ReadPipeLineElement(if(enable) dataStore(address) else PoisonedUInt(dataWidth))
+        pipeLine += ReadPipeLineElement(if(enable) dataStore(address) else Concrete.poisonedUInt(dataWidth))
       }
       else {
-        data = if(enable) dataStore(address) else PoisonedUInt(dataWidth)
+        data = if(enable) dataStore(address) else Concrete.poisonedUInt(dataWidth)
       }
     }
     override def toString: String = {
@@ -282,14 +282,14 @@ class Memory(
   case class ReadWritePort(portName: String) extends MemoryPort {
     val latency:   Int           = readLatency
     var writeMode: Boolean       = false
-    var readData:  Concrete      = ConcreteUInt(0, dataWidth)
+    var readData:  Concrete      = Concrete.poisonedUInt(dataWidth)
     var mask:      Concrete      = ConcreteUInt(0, dataWidth)
 
     case class ReadPipeLineElement(readPipeLineData: Concrete) {
       override def toString: String = s"[${readPipeLineData.value}]"
     }
     val readPipeLine : ArrayBuffer[ReadPipeLineElement] = {
-      ArrayBuffer.fill(readLatency)(ReadPipeLineElement(ConcreteUInt(0, dataWidth)))
+      ArrayBuffer.fill(readLatency)(ReadPipeLineElement(Concrete.poisonedUInt(dataWidth)))
     }
 
     case class WritePipeLineElement(enable: Boolean, address: Int, data: Concrete, mask: Concrete) {
@@ -314,7 +314,7 @@ class Memory(
           readData = dataStore(address)
         }
         else {
-          readPipeLine(0) = ReadPipeLineElement(if(enable) dataStore(address) else PoisonedUInt(dataWidth))
+          readPipeLine(0) = ReadPipeLineElement(if(enable) dataStore(address) else Concrete.poisonedUInt(dataWidth))
         }
       }
     }
@@ -339,10 +339,10 @@ class Memory(
     def cycle(): Unit = {
       if(readLatency > 0) {
         readData = readPipeLine.remove(0).readPipeLineData
-        readPipeLine += ReadPipeLineElement(if(enable) dataStore(address) else PoisonedUInt(dataWidth))
+        readPipeLine += ReadPipeLineElement(if(enable) dataStore(address) else Concrete.poisonedUInt(dataWidth))
       }
       else {
-        readData = if(enable) dataStore(address) else PoisonedUInt(dataWidth)
+        readData = if(enable) dataStore(address) else Concrete.poisonedUInt(dataWidth)
       }
 
       if(writeLatency > 0) {

--- a/src/main/scala/firrtl_interpreter/TypeInstanceFactory.scala
+++ b/src/main/scala/firrtl_interpreter/TypeInstanceFactory.scala
@@ -19,8 +19,8 @@ object TypeInstanceFactory {
   }
   def apply(template: Concrete, value: BigInt): Concrete = {
     template match {
-      case ConcreteUInt(_, width) => ConcreteUInt(value, width)
-      case ConcreteSInt(_, width) => ConcreteSInt(value, width)
+      case ConcreteUInt(_, width, p) => ConcreteUInt(value, width, p)
+      case ConcreteSInt(_, width, p) => ConcreteSInt(value, width, p)
     }
   }
 }

--- a/src/test/scala/firrtl_interpreter/ConcreteSpec.scala
+++ b/src/test/scala/firrtl_interpreter/ConcreteSpec.scala
@@ -453,4 +453,29 @@ class ConcreteSpec extends FlatSpec with Matchers {
     }
     ConcreteSInt(BigInt(randomWidth, random) * sign, width)
   }
+
+  behavior of "UInt with negative values"
+
+  it should "not allow negative inputs" in {
+    intercept[InterpreterException] {
+      ConcreteUInt(-1, 4)
+    }
+  }
+
+  it should "not be possible to create a negative UInt from various operations" in {
+    val a = ConcreteSInt(-1, 6)
+    val b = ConcreteSInt(-1, 6)
+    val z = ConcreteSInt(0, 6)
+    val c = a & b
+    c.value should be (BigInt("111111", 2))
+
+    val d = a | z
+    d.value should be (BigInt("111111", 2))
+
+    val e = a ^ z
+    e.value should be (BigInt("111111", 2))
+
+    val f = a.cat(b)
+    f.value should be (BigInt("1"*12, 2))
+  }
 }

--- a/src/test/scala/firrtl_interpreter/PoisonSpec.scala
+++ b/src/test/scala/firrtl_interpreter/PoisonSpec.scala
@@ -1,0 +1,64 @@
+// See LICENSE for license details.
+
+package firrtl_interpreter
+
+import org.scalatest.{Matchers, FreeSpec}
+
+//scalastyle:off magic.number
+class PoisonSpec extends FreeSpec with Matchers {
+  "poison should propagate through evaluation" in {
+    val input =
+      """
+        |circuit Poison :
+        |  module Poison :
+        |    input u_in : UInt<4>
+        |    input s_in : SInt<4>
+        |    output s_out: UInt<4>
+        |
+        |    node T_1 = add(u_in, s_in)
+        |    node T_2 = bits(T_1, 3, 0)
+        |    s_out <= T_2
+      """.stripMargin
+
+    val tester = new InterpretiveTester(input)
+
+    //TODO: need to fix Firrtl issues #308 before this test
+    //does not randomly blow up.
+//    tester.interpreter.setVerbose(true)
+//
+//    tester.poke("u_in", Concrete.poisonedUInt(10))
+//    tester.poke("s_in", Concrete.poisonedSInt(10))
+//
+//    tester.peekConcrete("s_out").toString should include ("P")
+//
+//    tester.poke("u_in", Concrete.poisonedUInt(10))
+//    tester.poke("s_in", 10)
+//
+//    tester.peekConcrete("s_out").toString should include ("P")
+//
+//    tester.poke("u_in", 77)
+//    tester.poke("s_in", Concrete.poisonedSInt(10))
+//
+//    tester.peekConcrete("s_out").toString should include ("P")
+//
+//    tester.poke("u_in", 10)
+//    tester.poke("s_in", 10)
+//
+//    tester.peekConcrete("s_out").toString should not include "P"
+
+//    val (i, j) = (BigInt(1), BigInt(15))
+//    tester.poke("u_in", ConcreteUInt(j, 10))
+//    tester.poke("s_in", ConcreteSInt(i, 10))
+//    println(s"$i.S + $j.U => ${tester.peek("s_out")}")
+
+//    val (lo, hi) = TestUtils.extremaOfSIntOfWidth(10)
+//    val uhi: BigInt = TestUtils.allOnes(10)
+//    for(i <- lo to hi) {
+//      for(j <- Big0 to uhi) {
+//        tester.poke("u_in", ConcreteUInt(j, 10))
+//        tester.poke("s_in", ConcreteSInt(i, 10))
+//        println(s"$i.S + $j.U => ${tester.peek("s_out")}")
+//      }
+//    }
+  }
+}


### PR DESCRIPTION
poison is now a value within the ConcreteUInt and ConcreteSInt types.  This allows it flow through the interpreter but be retained.  This PR fixes a problem reported by @jackkoenig where extract bits threw an exception when it encountered a poisoned value