### PR TITLE
Add execution harness stuff to the interpreter

### DIFF
--- a/src/main/scala/firrtl_interpreter/CircuitState.scala
+++ b/src/main/scala/firrtl_interpreter/CircuitState.scala
@@ -69,7 +69,7 @@ case class CircuitState(
     vcdOutputFileName = fileName
   }
   def writeVCD(): Unit = {
-    vcdLoggerOption.get.write(vcdOutputFileName)
+    vcdLoggerOption.foreach { _.write(vcdOutputFileName) }
   }
   def disableVCD(): Unit = {
     vcdLoggerOption.foreach { vcd =>

--- a/src/main/scala/firrtl_interpreter/Driver.scala
+++ b/src/main/scala/firrtl_interpreter/Driver.scala
@@ -1,0 +1,77 @@
+// See LICENSE for license details.
+
+package firrtl_interpreter
+
+import firrtl.ExecutionOptionsManager
+
+case class InterpreterOptions(
+    writeVCD: Boolean = false,
+    setVerbose: Boolean = false,
+    setOrderedExec: Boolean = false)
+  extends firrtl.ComposableOptions {
+
+  def vcdOutputFileName(optionsManager: ExecutionOptionsManager): String = {
+    if(writeVCD) {
+      s"${optionsManager.getBuildFileName("vcd")}"
+    }
+    else {
+      ""
+    }
+  }
+}
+
+trait HasInterpreterOptions {
+  self: ExecutionOptionsManager =>
+
+  var interpreterOptions = InterpreterOptions()
+
+  parser.note("firrtl-interpreter-options")
+
+  parser.opt[Unit]("fint-write-vcd")
+    .abbr("fiwv")
+    .foreach { _ =>
+      interpreterOptions = interpreterOptions.copy(writeVCD = true)
+    }
+    .text("writes vcd execution log, filename will be base on top")
+
+  parser.opt[Unit]("fint-verbose")
+    .abbr("fiv")
+    .foreach {_ =>
+      interpreterOptions = interpreterOptions.copy(setVerbose = true)
+    }
+    .text("makes interpreter very verbose")
+
+  parser.opt[Unit]("fint-ordered-exec")
+    .abbr("fioe")
+    .foreach { _ =>
+    interpreterOptions = interpreterOptions.copy(setOrderedExec = true)
+  }
+    .text("operates on dependencies optimally, can increase overhead, makes verbose mode easier to read")
+
+
+}
+
+object Driver {
+
+  def execute(
+      firrtlInput: String,
+      optionsManager: ExecutionOptionsManager with HasInterpreterOptions): Option[InterpretiveTester] = {
+    val tester = new InterpretiveTester(firrtlInput, optionsManager)
+
+    Some(tester)
+  }
+
+  def execute(
+               args: Array[String],
+               firrtlInput: String
+             ): Option[InterpretiveTester] = {
+    val optionsManager = new ExecutionOptionsManager("firrtl-interpreter") with HasInterpreterOptions
+
+    optionsManager.parser.parse(args) match {
+      case true =>
+        execute(firrtlInput, optionsManager)
+      case _ =>
+        None
+    }
+  }
+}

--- a/src/main/scala/firrtl_interpreter/FirrtlTerp.scala
+++ b/src/main/scala/firrtl_interpreter/FirrtlTerp.scala
@@ -71,7 +71,6 @@ class FirrtlTerp(ast: Circuit) extends SimpleLogger {
     circuitState = circuitState
   )
   val timer = evaluator.timer
-  println("evaluator created")
 
   def getValue(name: String): Concrete = {
     assert(dependencyGraph.validNames.contains(name),

--- a/src/test/scala/firrtl_interpreter/DriverSpec.scala
+++ b/src/test/scala/firrtl_interpreter/DriverSpec.scala
@@ -1,0 +1,29 @@
+// See LICENSE for license details.
+
+package firrtl_interpreter
+
+import org.scalatest.{Matchers, FreeSpec}
+
+class DriverSpec extends FreeSpec with Matchers {
+  "The Driver class provides a simple caller with run-time parameters" - {
+    "topName must be set" in {
+      val input =
+        """
+          |circuit Dummy :
+          |  module Dummy :
+          |    input x : UInt<1>
+          |    output y : UInt<1>
+          |    y <= x
+        """.stripMargin
+      //      val interpreter = Driver.execute(Array.empty[String], input)
+      val interpreter = Driver.execute(Array("--fint-verbose"), input)
+
+      interpreter should not be empty
+
+      interpreter.foreach { tester =>
+        tester.poke("x", 1)
+        tester.expect("y", 1)
+      }
+    }
+  }
+}

--- a/src/test/scala/firrtl_interpreter/GCDTester.scala
+++ b/src/test/scala/firrtl_interpreter/GCDTester.scala
@@ -40,7 +40,7 @@ class GCDTester extends FlatSpec with Matchers {
 
 
   it should "run with InterpretedTester" in {
-    new InterpretiveTester(gcdFirrtl, vcdOutputFileName = "gcd.vcd") {
+    new InterpretiveTester(gcdFirrtl) {
       // interpreter.setVerbose()
       step(1)
       poke("io_a", 34)
@@ -55,8 +55,6 @@ class GCDTester extends FlatSpec with Matchers {
         step(1)
       }
       expect("io_z", 17)
-
-      writeVCD()
     }
   }
 }

--- a/src/test/scala/firrtl_interpreter/LifeCellSpec.scala
+++ b/src/test/scala/firrtl_interpreter/LifeCellSpec.scala
@@ -1,6 +1,7 @@
 // See LICENSE for license details.
 package firrtl_interpreter
 
+import firrtl.ExecutionOptionsManager
 import org.scalatest.{FlatSpec, Matchers}
 
 class LifeCellSpec extends FlatSpec with Matchers {
@@ -46,8 +47,11 @@ class LifeCellSpec extends FlatSpec with Matchers {
         |    io.is_alive <= T_36
         |      """.stripMargin
 
-    new InterpretiveTester(input, vcdOutputFileName = "life_cell.vcd") {
-      interpreter.evaluator.useTopologicalSortedKeys = true
+    val optionsManager = new ExecutionOptionsManager("firrtl-interpreter") with HasInterpreterOptions {
+      interpreterOptions = InterpreterOptions(writeVCD = true)
+    }
+
+    new InterpretiveTester(input, optionsManager) {
       // setVerbose()
       step(1)
 
@@ -90,7 +94,6 @@ class LifeCellSpec extends FlatSpec with Matchers {
         0,0,0,
         0,0,0
       )
-      setVerbose(true)
       step(1)
       expect("io_is_alive", 0)
 


### PR DESCRIPTION
see firrtl ComposableOptions
make vcd logger write options safe
calling report will close a pending vcd dump

Depends on [Firrtl PR 337](/ucb-bar/firrtl/pull/337)
Depends on [Chisel PR 325](/ucb-bar/chisel3/pull/325)