### PR TITLE
Add option to set expression stack depth.

### DIFF
--- a/src/main/scala/firrtl_interpreter/Driver.scala
+++ b/src/main/scala/firrtl_interpreter/Driver.scala
@@ -10,7 +10,9 @@ case class InterpreterOptions(
     setOrderedExec:    Boolean              = false,
     allowCycles:       Boolean              = false,
     randomSeed:        Long                 = System.currentTimeMillis(),
-    blackBoxFactories: Seq[BlackBoxFactory] = Seq.empty)
+    blackBoxFactories: Seq[BlackBoxFactory] = Seq.empty,
+    maxExecutionDepth: Long                 = ExpressionExecutionStack.defaultMaxExecutionDepth
+    )
   extends firrtl.ComposableOptions {
 
   def vcdOutputFileName(optionsManager: ExecutionOptionsManager): String = {
@@ -66,6 +68,13 @@ trait HasInterpreterOptions {
     }
     .text("seed used for random numbers generated for tests and poison values, default is current time in ms")
 
+  parser.opt[Long]("fint-max-execution-depth")
+    .abbr("fmed")
+      .valueName("<long-value>")
+    .foreach { x =>
+      interpreterOptions = interpreterOptions.copy(maxExecutionDepth = x)
+    }
+    .text("depth of stack used to evaluate expressions")
 
 }
 

--- a/src/main/scala/firrtl_interpreter/Driver.scala
+++ b/src/main/scala/firrtl_interpreter/Driver.scala
@@ -11,8 +11,7 @@ case class InterpreterOptions(
     allowCycles:       Boolean              = false,
     randomSeed:        Long                 = System.currentTimeMillis(),
     blackBoxFactories: Seq[BlackBoxFactory] = Seq.empty,
-    maxExecutionDepth: Long                 = ExpressionExecutionStack.defaultMaxExecutionDepth
-    )
+    maxExecutionDepth: Long                 = ExpressionExecutionStack.defaultMaxExecutionDepth)
   extends firrtl.ComposableOptions {
 
   def vcdOutputFileName(optionsManager: ExecutionOptionsManager): String = {
@@ -69,7 +68,7 @@ trait HasInterpreterOptions {
     .text("seed used for random numbers generated for tests and poison values, default is current time in ms")
 
   parser.opt[Long]("fint-max-execution-depth")
-    .abbr("fmed")
+    .abbr("fimed")
       .valueName("<long-value>")
     .foreach { x =>
       interpreterOptions = interpreterOptions.copy(maxExecutionDepth = x)

--- a/src/main/scala/firrtl_interpreter/ExpressionExecutionStack.scala
+++ b/src/main/scala/firrtl_interpreter/ExpressionExecutionStack.scala
@@ -7,9 +7,13 @@ import firrtl.ir.Expression
 import scala.collection.mutable
 import scala.collection.mutable.ArrayBuffer
 
+object ExpressionExecutionStack {
+  val defaultMaxExecutionDepth: Long = 1000
+}
+
 class ExpressionExecutionStack(parent: LoFirrtlExpressionEvaluator) {
   val dependencyGraph = parent.dependencyGraph
-  val MaxExecutionDepth = 1000
+  var MaxExecutionDepth = ExpressionExecutionStack.defaultMaxExecutionDepth
   def allowCombinationalLoops: Boolean = parent.allowCombinationalLoops
 
   val expressionStack = new ArrayBuffer[StackItem]
@@ -31,7 +35,7 @@ class ExpressionExecutionStack(parent: LoFirrtlExpressionEvaluator) {
     var returnValue = true
     expressionStack += StackItem(keyOption, expression)
     if(expressionStack.length > MaxExecutionDepth) {
-      throw new InterruptedException(s"ExpressionStack to deep, max is $MaxExecutionDepth")
+      throw new InterruptedException(s"Expression Stack too deep, max is $MaxExecutionDepth")
     }
     keyOption.foreach { expressionKey =>
       if(stackKeys.contains(expressionKey)) {

--- a/src/main/scala/firrtl_interpreter/FirrtlRepl.scala
+++ b/src/main/scala/firrtl_interpreter/FirrtlRepl.scala
@@ -57,6 +57,7 @@ class FirrtlRepl(optionsManager: ExecutionOptionsManager with HasReplConfig with
     currentInterpeterOpt.foreach { _=>
       interpreter.evaluator.allowCombinationalLoops = interpreterOptions.allowCycles
       interpreter.evaluator.useTopologicalSortedKeys = interpreterOptions.setOrderedExec
+      interpreter.evaluator.evaluationStack.MaxExecutionDepth = interpreterOptions.maxExecutionDepth
       interpreter.setVerbose(interpreterOptions.setVerbose)
 
       console.println(s"Flags: $showFlags")

--- a/src/main/scala/firrtl_interpreter/InterpretiveTester.scala
+++ b/src/main/scala/firrtl_interpreter/InterpretiveTester.scala
@@ -30,6 +30,8 @@ class InterpretiveTester(
 
   val blackBoxFactories = optionsManager.interpreterOptions.blackBoxFactories
 
+  interpreter.evaluator.evaluationStack.MaxExecutionDepth = interpreterOptions.maxExecutionDepth
+
   setVerbose(interpreterOptions.setVerbose)
 
   if(interpreterOptions.writeVCD) {


### PR DESCRIPTION
Add option `--fint-max-execution-depth` (abbreviated `fmed`) to set the expression evaluation stack depth.

I was running some PFB tests with a large number of taps and exceeded the default of 1000.