### PR TITLE
A number of ease of use features for interpreter

### DIFF
--- a/src/main/scala/firrtl_interpreter/FirrtlRepl.scala
+++ b/src/main/scala/firrtl_interpreter/FirrtlRepl.scala
@@ -50,7 +50,7 @@ class FirrtlRepl(optionsManager: ExecutionOptionsManager with HasReplConfig with
   var inScript = false
   val scriptFactory = ScriptFactory(this)
   var currentScript: Option[Script] = None
-  val intPattern = """(-?\d+)""".r
+  val IntPattern = """(-?\d+)""".r
 
   def loadSource(input: String): Unit = {
     currentInterpeterOpt = Some(FirrtlTerp(input, blackBoxFactories = interpreterOptions.blackBoxFactories))
@@ -87,7 +87,7 @@ class FirrtlRepl(optionsManager: ExecutionOptionsManager with HasReplConfig with
     currentScript = scriptFactory(fileName)
     currentScript match {
       case Some(script) =>
-        console.println(s"loaded script file ${script.length} with ${script.fileName} lines")
+        console.println(s"loaded script file ${script.fileName} with ${script.length} lines")
       case _ =>
     }
   }
@@ -108,19 +108,19 @@ class FirrtlRepl(optionsManager: ExecutionOptionsManager with HasReplConfig with
     def getTwoArgs(failureMessage: String,
                    arg1Option: Option[String] = None,
                    arg2Option: Option[String] = None
-                  ): Option[(String,String)] = {
+                  ): (Option[String],Option[String]) = {
       if(args.length == 3) {
-        Some(args(1), args(2))
+        (Some(args(1)), Some(args(2)))
       }
-      else if(args.length == 2 && arg2Option.isDefined) {
-        Some(args(1), arg2Option.get)
+      else if(args.length == 2) {
+        (Some(args(1)), arg2Option)
       }
-      else if(args.length == 1 && arg1Option.isDefined && arg2Option.isDefined) {
-        Some(arg1Option.get, arg2Option.get)
+      else if(args.length == 1) {
+        (arg1Option, arg2Option)
       }
       else {
         error(failureMessage)
-        None
+        (None, None)
       }
     }
     //noinspection ScalaStyle
@@ -174,37 +174,75 @@ class FirrtlRepl(optionsManager: ExecutionOptionsManager with HasReplConfig with
         }
       },
       new Command("run") {
-        def usage: (String, String) = ("run [linesToRun|all|reset]", "run loaded script")
+        def usage: (String, String) = ("run [linesToRun|all|list|reset]", "run loaded script")
         override def completer: Option[ArgumentCompleter] = {
           Some(new ArgumentCompleter(
             new StringsCompleter({"run"}),
             new StringsCompleter(jlist(Seq("all", "reset", "list")))
           ))
         }
+        def handleList(script: Script, listArg: Option[String]): Unit = {
+          val (min, max) = listArg match {
+            case Some(IntPattern(intString)) =>
+              val windowHalfSize = intString.toInt
+              (script.currentLine + 1 - windowHalfSize, script.currentLine + 2 + windowHalfSize)
+            case Some(other) =>
+              console.println(s"run list parameter=$other, parameter must be an positive integer")
+              (0, 0)
+            case _ =>
+              (0, script.length)
+          }
+          console.println(
+            script.lines.zipWithIndex.flatMap { case (line, index) =>
+              if(index >= min && index < max) {
+                if (index == script.currentLine + 1) {
+                  Some(Console.GREEN + f"$index%3d $line" + Console.RESET)
+                }
+                else {
+                  Some(f"$index%3d $line")
+                }
+              }
+              else {
+                None
+              }
+            }.mkString("\n")
+          )
+        }
         // scalastyle:off cyclomatic.complexity
         def run(args: Array[String]): Unit = {
           currentScript match {
             case Some(script) =>
-              getOneArg("run [linesToRun|all|reset|list]", argOption = Some("all")) match {
-                case Some("all")   =>
+              getTwoArgs("run [lines|skip [n]|set n|all|reset|list [n]], default is 1 => run 1 line",
+                arg1Option = Some("1"), arg2Option = None) match {
+                case (Some("all"), _)   =>
                   console.println("run all")
                   if(script.atEnd) { script.reset() }
                   else { script.runRemaining() }
-                case Some("reset") => script.reset()
-                  console.println("run reset")
-                case Some("list") =>
-                  console.println(
-                    script.lines.zipWithIndex.map { case (line, index) =>
-                      f"$index%3d $line"
-                    }.mkString("\n")
-                  )
-                case Some(intPattern(intString)) =>
-                  console.println(s"run $intString")
+                case (Some("reset"), _) =>
+                  script.reset()
+                  handleList(script, Some("2"))
+                case (Some("list"), listArg) =>
+                  handleList(script, listArg)
+                case (Some("skip"), listArg) =>
+                  val skip = listArg match {
+                    case Some(IntPattern(intString)) => intString.toInt
+                    case _ => 1
+                  }
+                  script.setSkipLines(skip)
+                case (Some("set"), listArg) =>
+                  listArg match {
+                    case Some(IntPattern(intString)) =>
+                      script.setLine(intString.toInt)
+                      handleList(script, Some("2"))
+                    case _ =>
+                      console.println("must specify set line number")
+                  }
+                case (Some(IntPattern(intString)), _) =>
                   val linesToRun = intString.toInt
                   script.setLinesToRun(linesToRun)
-                case None =>
+                case (None, None) =>
                   script.runRemaining()
-                case Some(arg) =>
+                case (Some(arg), _) =>
                   error(s"unrecognized run_argument $arg")
               }
             case _ =>
@@ -258,7 +296,7 @@ class FirrtlRepl(optionsManager: ExecutionOptionsManager with HasReplConfig with
         }
         def run(args: Array[String]): Unit = {
           getTwoArgs("poke inputPortName value") match {
-            case Some((portName, valueString)) =>
+            case (Some(portName), Some(valueString)) =>
               try {
                 if(valueString.startsWith("0x")) {
                   val hexValue = BigInt(valueString.drop(2), 16)
@@ -297,7 +335,7 @@ class FirrtlRepl(optionsManager: ExecutionOptionsManager with HasReplConfig with
         }
         def run(args: Array[String]): Unit = {
           getTwoArgs("rpoke regex value") match {
-            case Some((pokeRegex, valueString)) =>
+            case (Some(pokeRegex), Some(valueString)) =>
               try {
                 val pokeValue = {
                   if(valueString.startsWith("0x")) {
@@ -427,9 +465,39 @@ class FirrtlRepl(optionsManager: ExecutionOptionsManager with HasReplConfig with
           console.println(interpreter.circuitState.prettyString())
         }
       },
+      new Command("poison") {
+        def usage: (String, String) = ("poison",
+          "poison everything)")
+        def run(args: Array[String]): Unit = {
+          for{
+            (component, value) <- interpreter.circuitState.inputPorts ++ interpreter.circuitState.outputPorts ++
+              interpreter.circuitState.registers ++ interpreter.circuitState.nextRegisters
+          } {
+            interpreter.setValue(component, TypeInstanceFactory(value))
+          }
+          for(memory <- interpreter.circuitState.memories.values) {
+            for(memoryIndex <- 0 until memory.dataStore.length) {
+              memory.dataStore.update(memoryIndex, TypeInstanceFactory(memory.dataType))
+            }
+          }
+          console.println(interpreter.circuitState.prettyString())
+        }
+      },
       new Command("reset") {
         def usage: (String, String) = ("reset [numberOfSteps]",
           "assert reset (if present) for numberOfSteps (default 1)")
+        override def completer: Option[ArgumentCompleter] = {
+          if(currentInterpeterOpt.isEmpty) {
+            None
+          }
+          else {
+            Some(new ArgumentCompleter(
+              new StringsCompleter({
+                "reset"
+              })
+            ))
+          }
+        }
         def run(args: Array[String]): Unit = {
           getOneArg("reset [numberOfSteps]", Some("1")) match {
             case Some(numberOfStepsString) =>
@@ -718,8 +786,13 @@ class FirrtlRepl(optionsManager: ExecutionOptionsManager with HasReplConfig with
     }
   }
 
+  /**
+    * gets the next line from either the current executing script or from the console.
+    * Strips comments from the line, may result in empty string, command parser is ok with that
+    * @return
+    */
   def getNextLine: String = {
-    currentScript match {
+    val rawLine = currentScript match {
       case Some(script) =>
         script.getNextLineOption match {
           case Some(line) =>
@@ -731,6 +804,7 @@ class FirrtlRepl(optionsManager: ExecutionOptionsManager with HasReplConfig with
       case _ =>
         console.readLine()
     }
+    rawLine.split("#").head
   }
 
   def scriptRunning: Boolean = {
@@ -760,14 +834,14 @@ class FirrtlRepl(optionsManager: ExecutionOptionsManager with HasReplConfig with
       try {
         val line = getNextLine
 
-        args = line.split(" ")
+        args = line.split(" +")
 
         if (args.length > 0) {
           if (Commands.commandMap.contains(args.head)) {
             Commands.commandMap(args.head).run(args.tail)
           }
           else {
-            error(s"unknown command $line, try help")
+            if(line.nonEmpty) error(s"unknown command $line, try help")
           }
         }
         else {
@@ -784,6 +858,7 @@ class FirrtlRepl(optionsManager: ExecutionOptionsManager with HasReplConfig with
           console.println(s"Exception occurred: ${e.getMessage}")
       }
     }
+
     console.println(s"saving history ${history.size()}")
     history.flush()
     console.shutdown()

--- a/src/main/scala/firrtl_interpreter/Script.scala
+++ b/src/main/scala/firrtl_interpreter/Script.scala
@@ -42,7 +42,18 @@ class Script(val fileName: String, val lines: Array[String]) {
   def length: Int = lines.length
 
   def setLinesToRun(n: Int): Unit = {
-    linesLeftToRun = n.max((lines.length - currentLine) + 1)
+    linesLeftToRun = n.min((lines.length - currentLine) + 1)
+  }
+
+  def setSkipLines(n: Int): Unit = {
+    for(i <- 0 until n) {
+      getNextLineOption
+    }
+  }
+
+  def setLine(n: Int): Unit = {
+    reset()
+    currentLine = n - 1
   }
 
   def runRemaining(): Unit = {
@@ -55,7 +66,7 @@ class Script(val fileName: String, val lines: Array[String]) {
 
   def reset(): Unit = {
     currentLine = -1
-    linesLeftToRun = lines.length
+    linesLeftToRun = 0
   }
 
   override def toString: String = {

--- a/src/main/scala/firrtl_interpreter/TypeInstanceFactory.scala
+++ b/src/main/scala/firrtl_interpreter/TypeInstanceFactory.scala
@@ -17,6 +17,13 @@ object TypeInstanceFactory {
       case _ => throw new InterpreterException(s"Unsupported LoFIRRTL type for interpreter $typ")
     }
   }
+  def apply(template: Concrete): Concrete = {
+    template match {
+      case u: ConcreteUInt => Concrete.poisonedUInt(u.width)
+      case s: ConcreteSInt => Concrete.poisonedSInt(s.width)
+      case _ => throw new InterpreterException(s"Unsupported LoFIRRTL type for interpreter $template")
+    }
+  }
   def apply(typ: Type, initialValue: BigInt, poisoned: Boolean = false): Concrete = {
     typ match {
       case u: UIntType => ConcreteUInt(initialValue, widthToInt(u.width))

--- a/src/main/scala/firrtl_interpreter/TypeInstanceFactory.scala
+++ b/src/main/scala/firrtl_interpreter/TypeInstanceFactory.scala
@@ -24,6 +24,14 @@ object TypeInstanceFactory {
       case _ => throw new InterpreterException(s"Unsupported LoFIRRTL type for interpreter $template")
     }
   }
+  def apply(typ: Concrete, poisoned: Boolean): Concrete = {
+    typ match {
+      case u: ConcreteUInt => Concrete.randomUInt(u.width, poisoned)
+      case s: ConcreteSInt => Concrete.randomSInt(s.width, poisoned)
+      case s: ConcreteClock => Concrete.randomClock()
+      case _ => throw new InterpreterException(s"Unsupported LoFIRRTL type for interpreter $typ")
+    }
+  }
   def apply(typ: Type, initialValue: BigInt, poisoned: Boolean = false): Concrete = {
     typ match {
       case u: UIntType => ConcreteUInt(initialValue, widthToInt(u.width))


### PR DESCRIPTION
fixed script loading message
lots of run fixes
 - run by itself runs 1 line of script
 - run n runs next n lines of script
 - run reset resets script to line 0
 - run set n sets next line of script to n (counts from zero)
 - run skip n skips next n lines of script (default 1 if n unspecified)
command may have a comment, delimited by #, this may be used in repl and in scripts
new command poison will poison the whole circuit