### PR TITLE
Support for VCD input scripts

### DIFF
--- a/src/main/scala/firrtl_interpreter/FirrtlTerp.scala
+++ b/src/main/scala/firrtl_interpreter/FirrtlTerp.scala
@@ -29,7 +29,7 @@ import scala.collection.mutable.ArrayBuffer
   *
   * @param ast the circuit to be simulated
   */
-class FirrtlTerp(ast: Circuit, val blackBoxFactories: Seq[BlackBoxFactory] = Seq.empty) extends SimpleLogger {
+class FirrtlTerp(val ast: Circuit, val blackBoxFactories: Seq[BlackBoxFactory] = Seq.empty) extends SimpleLogger {
   var lastStopResult: Option[Int] = None
   def stopped: Boolean = lastStopResult.nonEmpty
   def stopResult: Int  = lastStopResult.get
@@ -97,14 +97,15 @@ class FirrtlTerp(ast: Circuit, val blackBoxFactories: Seq[BlackBoxFactory] = Seq
     circuitState.setValue(name, value)
   }
 
-  def setValueWithBigInt(name: String, value: BigInt, force: Boolean = true): Concrete = {
+  def setValueWithBigInt(
+      name: String, value: BigInt, force: Boolean = true, registerPoke: Boolean = false): Concrete = {
     if(!force) {
       assert(circuitState.isInput(name),
         s"Error: setValue($name) not on input, use setValue($name, force=true) to override")
     }
     val concreteValue = TypeInstanceFactory(dependencyGraph.nameToType(name), value)
 
-    circuitState.setValue(name, concreteValue)
+    circuitState.setValue(name, concreteValue, registerPoke = registerPoke)
   }
 
   def hasInput(name: String): Boolean  = dependencyGraph.hasInput(name)

--- a/src/main/scala/firrtl_interpreter/InterpretiveTester.scala
+++ b/src/main/scala/firrtl_interpreter/InterpretiveTester.scala
@@ -59,7 +59,8 @@ class InterpretiveTester(
     if(interpreter.checkStopped(s"poke($name, $value)")) return
 
     try {
-      interpreter.setValueWithBigInt(name, value)
+      val isRegister = interpreter.circuitState.registers.contains(name)
+      interpreter.setValueWithBigInt(name, value, registerPoke = isRegister)
     }
     catch {
       case ie: InterpreterException =>
@@ -80,7 +81,8 @@ class InterpretiveTester(
     if(interpreter.checkStopped(s"poke($name, $value)")) return
 
     try {
-      interpreter.circuitState.setValue(name, value)
+      val isRegister = interpreter.circuitState.registers.contains(name)
+      interpreter.circuitState.setValue(name, value, registerPoke = isRegister)
     }
     catch {
       case ie: InterpreterException =>

--- a/src/main/scala/firrtl_interpreter/ReplConfig.scala
+++ b/src/main/scala/firrtl_interpreter/ReplConfig.scala
@@ -7,7 +7,10 @@ import firrtl.ExecutionOptionsManager
 case class ReplConfig(
     firrtlSourceName:  String  = "",
     scriptName:        String  = "",
-    firrtlSource:      String = "")
+    firrtlSource:      String = "",
+    useVcdScript:      Boolean = false,
+    vcdScriptOverride: String = "",
+    runScriptAtStart:  Boolean = false)
   extends firrtl.ComposableOptions
 
 trait HasReplConfig {
@@ -33,4 +36,30 @@ trait HasReplConfig {
     }
     .text("script file to load on startup, default is no file")
 
+  parser.opt[Unit]("fr-use-vcd-script")
+    .abbr("fruvs")
+    .foreach { _ =>
+      replConfig = replConfig.copy(useVcdScript = true)
+    }
+    .text("load vcd file as script, default is false")
+
+  parser.opt[String]("fr-vcd-script-override")
+    .abbr("frvso")
+    .valueName("<vcd-file>")
+    .foreach { x =>
+      replConfig = replConfig.copy(vcdScriptOverride = x, useVcdScript = true)
+    }
+    .text("load vcd file as script, default is false")
+
+  parser.opt[Unit]("fr-run-script-on-startup")
+    .abbr("frrsos")
+    .valueName("<vcd-file>")
+    .foreach { _ =>
+      replConfig = replConfig.copy(runScriptAtStart = true)
+    }
+    .text("run script immediately on startup")
+
+  def getVcdFileName: String = {
+    self.getBuildFileName("vcd", replConfig.vcdScriptOverride)
+  }
 }

--- a/src/main/scala/firrtl_interpreter/ReplVcdController.scala
+++ b/src/main/scala/firrtl_interpreter/ReplVcdController.scala
@@ -1,0 +1,355 @@
+// See LICENSE for license details.
+
+package firrtl_interpreter
+
+import firrtl_interpreter.vcd.VCD
+
+class ReplVcdController(val repl: FirrtlRepl, val interpreter: FirrtlTerp, val vcd: VCD) {
+  val console = repl.console
+
+  // The following three elements track state of running the vcd file
+  var currentTime = 0L
+  var currentTimeIndex = 0
+  val timeStamps = vcd.valuesAtTime.keys.toList.sorted.toArray
+
+  // The following control the current list state of the vcd file
+  var currentListLocation = 0
+  var currentListSize = 10
+
+  var testAfterRun = true
+
+  val IntPattern = """(-?\d+)""".r
+
+  val vcdCircuitState = interpreter.circuitState.clone
+
+  val inputs = {
+    vcd.scopeRoot.wires
+      .filter { wire =>
+        interpreter.circuitState.isInput(wire.name)
+      }
+      .map(_.name).toSet
+  }
+
+  val outputs = {
+    vcd.scopeRoot.wires.filter { wire =>
+      interpreter.circuitState.isOutput(wire.name)
+    }.toSet
+  }
+
+  def showInputMap(): Unit = {
+    vcd.scopeRoot.wires.foreach { wire =>
+      console.println(s"vcd top level wire $wire")
+    }
+  }
+
+  def now: String = {
+    s"Event: $currentTimeIndex Time: ${timeStamps(currentTimeIndex)}"
+  }
+
+  def showInputs(timeIndex: Int): Unit = {
+    var hasStep = false
+    if(timeIndex == currentTimeIndex) console.print(Console.GREEN)
+    console.println(now)
+    vcd.valuesAtTime(timeStamps(timeIndex)).foreach { change =>
+      if(inputs.contains(change.wire.name)) {
+        if(change.wire.name == "clock" && change.value == BigInt(0)) {
+          hasStep = true
+        }
+        else {
+          console.println(s"poke ${change.wire.name} ${change.value}")
+        }
+      }
+    }
+    if(hasStep) {
+      console.println(s"step 1")
+    }
+    if(timeIndex == currentTimeIndex) console.print(Console.RESET)
+  }
+
+  def showChanges(timeIndex: Int): Unit = {
+    var hasStep = false
+    if(timeIndex == currentTimeIndex) console.print(Console.GREEN)
+    console.println(now)
+    vcd.valuesAtTime(timeStamps(timeIndex)).foreach { change =>
+      if(change.wire.name == "clock" && change.value == BigInt(0)) {
+        hasStep = true
+      }
+      else if(inputs.contains(change.wire.name)) {
+        console.println(s"poke ${change.wire.name} ${change.value}")
+      }
+      else {
+        console.println(s"changed: ${change.wire.name} to ${change.value}")
+      }
+    }
+    if(hasStep) {
+      console.println(s"step 1")
+    }
+    if(timeIndex == currentTimeIndex) console.print(Console.RESET)
+  }
+
+  def stepOnPosEdgelock(): Boolean = {
+    var needToStep = false
+    vcd.valuesAtTime(timeStamps(currentTimeIndex)).find { change => change.wire.fullName == "clock"}.foreach { clock =>
+      needToStep = interpreter.circuitState.getValue(clock.wire.fullName) match {
+        case Some(previousValue) =>
+          previousValue.value == BigInt(0) && clock.value == BigInt(1)
+        case None => false
+      }
+    }
+
+    if(needToStep) {
+      console.println(s"vcd step called at $now")
+      interpreter.cycle(showState = false)
+    }
+    needToStep
+  }
+
+  //scalastyle:off method.length cyclomatic.complexity
+  /**
+    * Applies changes to circuit based on current vcd time step to current inputs.
+    *
+    * @note At time step zero all possible changes are applied.
+    * @return
+    */
+  def doChanges(): Boolean = {
+    console.println(s"$now ${"-" * 20}")
+    val stepped = stepOnPosEdgelock()
+
+    vcd.valuesAtTime(timeStamps(currentTimeIndex)).foreach { change =>
+      val name = change.wire.name
+      val fullName = change.wire.fullName
+      val newValue = change.value
+
+      if(inputs.contains(name)) {
+        console.println(s"poke $fullName $newValue")
+
+        interpreter.setValueWithBigInt(name, newValue)
+        vcdCircuitState.setInput(name, newValue)
+      }
+      else {
+        vcdCircuitState.getValue(name) match {
+          case Some(oldConcrete) =>
+            val newConcrete = TypeInstanceFactory.makeSimilar(oldConcrete, newValue, poisoned = false)
+            val isRegister = interpreter.circuitState.registers.contains(name)
+            //interpreter.setValueWithBigInt(name, newValue, registerPoke = isRegister)
+            //vcdCircuitState.setValue(name, newConcrete, registerPoke = isRegister)
+            if(currentTimeIndex < 1) {
+              console.println(s"setting: $fullName to ${newConcrete.value}")
+              interpreter.setValueWithBigInt(name, newValue, registerPoke = isRegister)
+            }
+            else {
+              console.println(s"recording: $fullName ${oldConcrete.value} to ${newConcrete.value}")
+            }
+            vcdCircuitState.setValue(name, newConcrete, registerPoke = isRegister)
+          case _ =>
+            if(vcdCircuitState.validNames.contains(fullName)) {
+              interpreter.dependencyGraph.nameToType.get(fullName).foreach { typ =>
+                val newConcrete = TypeInstanceFactory(typ, newValue, poisoned = false)
+                if(currentTimeIndex < 1) {
+                  console.println(s"setting: $fullName to ${newConcrete.value}")
+                  interpreter.setValueWithBigInt(name, newValue)
+                }
+                else {
+                  console.println(s"recording: $fullName to ${newConcrete.value}")
+                }
+                vcdCircuitState.setValue(name, newConcrete)
+              }
+            }
+            else {
+              // console.println(s"Don't know how to process entry: change $fullName to $newValue")
+            }
+        }
+      }
+    }
+    stepped
+  }
+
+  def hasStep(timeIndex: Int): Boolean = {
+    if(currentTimeIndex < timeStamps.length) {
+      vcd.valuesAtTime(timeStamps(timeIndex)).foreach { change =>
+        if(inputs.contains(change.wire.name)) {
+          if(change.wire.name == "clock" && change.value == BigInt(0)) {
+            return true
+          }
+        }
+      }
+    }
+    false
+  }
+
+  def runUsage: String = {
+    """vcd run                    run one event
+      |vcd run to step            run event until a step occurs
+      |vcd run to <event-number>  run up to given event-number
+      |vcd run <number-of-events> run this many events
+      |vcd run set <event>        set next event to run
+      |vcd run test               test outputs after each run command
+      |vcd run notest             do not test outputs after each run command
+      |    """.stripMargin
+  }
+
+  //scalastyle:off cyclomatic.complexity method.length
+  def run(parameters: Array[String]): Unit = {
+    parameters.toList match {
+      case Nil =>
+        if(currentTimeIndex < timeStamps.length) {
+          doChanges()
+          if(testAfterRun) checkCurrentValueOfOutputs()
+          currentTimeIndex += 1
+        }
+      case "to" :: tail => tail match {
+        case IntPattern(nString) :: _ =>
+          val n = nString.toInt
+          if(n <= currentTimeIndex) {
+            console.println(s"run to $n, error, $n must be greater then current time index ${currentTimeIndex + 1}")
+          }
+          else {
+            while (currentTimeIndex <= n & currentTimeIndex < timeStamps.length) {
+              doChanges()
+              currentTimeIndex += 1
+            }
+            if(testAfterRun) checkCurrentValueOfOutputs()
+          }
+        case "step" :: _ =>
+          while(currentTimeIndex < timeStamps.length && !doChanges()) {
+            // repeat until no more events or doChange returns false when step has occurred
+            currentTimeIndex += 1
+
+          }
+          if(testAfterRun) checkCurrentValueOfOutputs()
+        case "test" :: _ =>
+          testAfterRun = true
+        case "notest" :: _ =>
+          testAfterRun = false
+      }
+      case arg :: Nil =>
+        arg match {
+          case IntPattern(nString) =>
+            for {
+              events <- 0 until nString.toInt
+              if currentTimeIndex < timeStamps.length
+            } {
+              doChanges()
+              currentTimeIndex += 1
+            }
+            if(testAfterRun) checkCurrentValueOfOutputs()
+          case _ =>
+            console.println(s"Unknown run command ${parameters.mkString(" ")}")
+            console.println(runUsage)
+        }
+      case "set" :: tail => tail match {
+        case IntPattern(nString) :: _ =>
+          currentTimeIndex = nString.toInt
+        case _ =>
+          console.println(s"vcd next set requires event number")
+      }
+      case _ =>
+        console.println(s"Unknown next command ${parameters.mkString(" ")}")
+        console.println(runUsage)
+    }
+  }
+  //scalastyle:on cyclomatic.complexity
+
+  def checkCurrentValueOfOutputs(): Unit = {
+    console.println(s"Testing outputs $now ${"=" * 20}")
+    def show(mismatch: Boolean, message: String): Unit = {
+      val prefix = if(mismatch) Console.RED else ""
+      val suffix = if(mismatch) Console.RESET else ""
+      console.println(prefix + message + suffix)
+    }
+    for(key <- vcdCircuitState.outputPorts.keys) {
+      val value = interpreter.getValue(key)
+      val expected = vcdCircuitState.outputPorts(key)
+      (value.poisoned, expected.poisoned) match {
+        case (true, true) =>
+          show(mismatch = false, f"output $key is poison expected poison")
+        case (false, true) =>
+          show(mismatch = true, f"output $key is $value expected poison")
+        case (true, false) =>
+          show(mismatch = true, f"output $key is poisoned expected $expected")
+        case (false, false) =>
+          show(mismatch = value.value != expected.value, f"output $key is ${value.value} expected ${expected.value}")
+      }
+    }
+  }
+
+  def test(parameters: Array[String]): Unit = {
+    parameters.toList match {
+      case "outputs" :: _ =>
+        if(currentTimeIndex > 0) {
+          checkCurrentValueOfOutputs()
+        }
+
+      case _ =>
+        console.println(s"Unknown test command ${parameters.mkString(" ")}")
+    }
+  }
+
+  def show(lo: Int, hi: Int): Unit = {
+    for(timeIndex <- lo until hi) {
+      showChanges(timeIndex)
+    }
+  }
+
+  def showCurrent(): Unit = {
+    val (lo, hi) = (0.max(currentListLocation), timeStamps.length.min(currentListLocation + currentListSize))
+    show(lo, hi)
+    currentListLocation += currentListSize
+  }
+
+  def listUsage: String = {
+    """vcd list
+      |vcd list all
+      |vcd list <event-number>
+      |vcd list <event-number> <window-size>
+    """.stripMargin
+  }
+
+  def list(parameters: Array[String]): Unit = {
+    parameters.toList match {
+      case Nil =>
+        showCurrent()
+      case "all" :: _ =>
+        for(timeIndex <- timeStamps.indices) {
+          show(0, timeStamps.length)
+        }
+        currentListLocation = currentTimeIndex + 1
+      case IntPattern(nString) :: IntPattern(eventString) :: _ =>
+        currentListLocation = nString.toInt - 1
+        currentListSize = eventString.toInt
+        showCurrent()
+      case IntPattern(nString) :: _ =>
+        currentListLocation = nString.toInt - 1
+        showCurrent()
+      case _ =>
+        console.println(s"Unknown list command list ${parameters.mkString(" ")} should be more like")
+        console.println(listUsage)
+    }
+  }
+
+  def usage: String = {
+    runUsage + listUsage
+  }
+
+  /**
+    * command parser for vcd family of repl commands
+    *
+    * @param args arguments from user
+    */
+  def processListCommand(args: Array[String]): Unit = {
+    args.headOption match {
+      case Some("inputs") =>
+        showInputMap()
+      case Some("run") =>
+        run(args.tail)
+      case Some("list") =>
+        list(args.tail)
+      case Some("test") =>
+        test(args.tail)
+      case Some("help") =>
+        console.println(usage)
+      case _ =>
+        console.println(usage)
+    }
+  }
+}

--- a/src/main/scala/firrtl_interpreter/TypeInstanceFactory.scala
+++ b/src/main/scala/firrtl_interpreter/TypeInstanceFactory.scala
@@ -46,4 +46,10 @@ object TypeInstanceFactory {
       case ConcreteSInt(_, width, p) => ConcreteSInt(value, width, p)
     }
   }
+  def makeSimilar(template: Concrete, value: BigInt, poisoned: Boolean): Concrete = {
+    template match {
+      case ConcreteUInt(_, width, p) => ConcreteUInt(value, width, poisoned)
+      case ConcreteSInt(_, width, p) => ConcreteSInt(value, width, poisoned)
+    }
+  }
 }

--- a/src/test/scala/firrtl_interpreter/CircuitStateSpec.scala
+++ b/src/test/scala/firrtl_interpreter/CircuitStateSpec.scala
@@ -69,8 +69,8 @@ class CircuitStateSpec extends FlatSpec with Matchers {
     c.getValue("wire0").get.poisoned should be (true)
     c.isStale = false
     c.cycle()
-    c.nextRegisters.size should be (0)
-    c.ephemera.size should be (0)
+    c.nextRegisters.size should be (2)
+    c.ephemera.size should be (1)
   }
 
   it should "have mutable type instances, distinct in copy" in {

--- a/src/test/scala/firrtl_interpreter/GCDTester.scala
+++ b/src/test/scala/firrtl_interpreter/GCDTester.scala
@@ -40,21 +40,22 @@ class GCDTester extends FlatSpec with Matchers {
 
 
   it should "run with InterpretedTester" in {
-    new InterpretiveTester(gcdFirrtl) {
-      // interpreter.setVerbose()
-      step(1)
-      poke("io_a", 34)
-      poke("io_b", 17)
-      poke("io_e", 1)
-      step(1)
+    val tester = new InterpretiveTester(gcdFirrtl)
+    // interpreter.setVerbose()
+    List((1, 1, 1), (34, 17, 17), (8, 12, 4)).foreach { case (x, y, z) =>
+      tester.step(1)
+      tester.poke("io_a", x)
+      tester.poke("io_b", y)
+      tester.poke("io_e", 1)
+      tester.step(1)
 
-      poke("io_e", 0)
-      step(1)
+      tester.poke("io_e", 0)
+      tester.step(1)
 
-      while(peek("io_v") != Big1) {
-        step(1)
+      while (tester.peek("io_v") != Big1) {
+        tester.step(1)
       }
-      expect("io_z", 17)
+      tester.expect("io_z", z)
     }
   }
 }

--- a/src/test/scala/firrtl_interpreter/vcd/VCDSpec.scala
+++ b/src/test/scala/firrtl_interpreter/vcd/VCDSpec.scala
@@ -47,6 +47,8 @@ class VCDSpec extends FlatSpec with Matchers {
     vcd.addWire("carol", 16)
     vcd.addWire("ted", 3)
 
+    // time starts at -1 to support initialized values
+    vcd.incrementTime()
     for(i <- 0 to 10) {
       vcd.wireChanged("bob", i)
       vcd.wireChanged("carol", i / 2)


### PR DESCRIPTION
VCD now has read method that will read a vcd file and load all data
 - The desired scope can be extracted from within outer wrapping scopes
Repl now has support for VCD
 - VCD input file can be selected
 - VCD file can be run like current script run commands
 - Repl script can be autoinvoked at startup
   - Combined with VCD, a script that runs the desired VCD can be created and run
   - Ths will help verification to run a complex script in order to do concolic testing
Cleaner command implementation for vcd should be propagated to other complex commands
ReplVCD controller needed some changes in order to process VCD
 - Ability to clone CircuitState
 - More correct ability to poke registers
 - Register poke change register's value as RHS
 - Handles positive edge transition of clock input (when present) as time to cycle circuit
Now next values for registers and ephemera are not cleared, so they should be available for peeking at all times
Show stack trace of non interpreter exceptions in repl, aids greatly in debugging