### PR TITLE
[stevo]: log LoFirrtl instead of println so it obeys verbosity flag

### DIFF
--- a/src/main/scala/firrtl_interpreter/FirrtlTerp.scala
+++ b/src/main/scala/firrtl_interpreter/FirrtlTerp.scala
@@ -35,8 +35,8 @@ class FirrtlTerp(val ast: Circuit, val blackBoxFactories: Seq[BlackBoxFactory] =
   def stopResult: Int  = lastStopResult.get
 
   val loweredAst = ToLoFirrtl.lower(ast)
-  println("LoFirrtl" + "="*120)
-  println(loweredAst.serialize)
+  log("LoFirrtl" + "="*120)
+  log(loweredAst.serialize)
 
   /**
     * turns on evaluator debugging. Can make output quite


### PR DESCRIPTION
I generally don't want the LoFirrtl output printed unless I'm debugging. Running a suite of tests dumps tons of text, which is becoming a problem if I can't not print this.