### PR TITLE
A bunch of changes to fix creation of VCD files by interpreter

### DIFF
--- a/src/main/scala/firrtl_interpreter/CircuitState.scala
+++ b/src/main/scala/firrtl_interpreter/CircuitState.scala
@@ -124,8 +124,8 @@ case class CircuitState(
     */
   def cycle(): Unit = {
     vcdLoggerOption.foreach { vcd =>
-      vcd.incrementTime(10)
       vcd.raiseClock
+      vcd.incrementTime(10)
     }
     registers.keys.foreach { key =>
       registers(key) = nextRegisters(key)
@@ -139,8 +139,8 @@ case class CircuitState(
     stateCounter += 1
 
     vcdLoggerOption.foreach { vcd =>
-      vcd.incrementTime(10)
       vcd.lowerClock
+      vcd.incrementTime(10)
     }
   }
   def cycleMemories(): Unit = {

--- a/src/main/scala/firrtl_interpreter/DependencyGraph.scala
+++ b/src/main/scala/firrtl_interpreter/DependencyGraph.scala
@@ -83,6 +83,7 @@ object DependencyGraph extends SimpleLogger {
         log(s"declaration:WDefInstance:$instanceName:$moduleName prefix now $newPrefix")
         processModule(newPrefix, subModule, dependencyGraph)
         dependencyGraph.addSourceInfo(newPrefix, info)
+        dependencyGraph.addInstanceName(instanceName, moduleName)
         s
       case DefNode(info, name, expression) =>
         log(s"declaration:DefNode:$name:${expression.serialize} ${renameExpression(expression).serialize}")
@@ -276,6 +277,7 @@ class DependencyGraph(val circuit: Circuit,
   val stops            = new ArrayBuffer[Stop]
   val prints           = new ArrayBuffer[Print]
   val sourceInfo       = new mutable.HashMap[String, String]
+  val instanceNames    = new mutable.HashMap[String, String]
 
   val inputPorts       = new mutable.HashSet[String]
   val outputPorts      = new mutable.HashSet[String]
@@ -324,6 +326,10 @@ class DependencyGraph(val circuit: Circuit,
       case f: FileInfo => sourceInfo(name) = f.toString
       case _ => // I don't know what to do with other annotations
     }
+  }
+
+  def addInstanceName(instanceName: String, moduleName: String): Unit = {
+    instanceNames(instanceName) = moduleName
   }
 
   def hasInput(name: String): Boolean = inputPorts.contains(name)

--- a/src/main/scala/firrtl_interpreter/FirrtlRepl.scala
+++ b/src/main/scala/firrtl_interpreter/FirrtlRepl.scala
@@ -1003,6 +1003,7 @@ class FirrtlRepl(val optionsManager: ExecutionOptionsManager with HasReplConfig 
       catch {
         case ie: InterpreterException =>
           console.println(s"Interpreter Exception occurred: ${ie.getMessage}")
+          ie.printStackTrace()
         case e: NullPointerException =>
           error(s"Null pointer exception, please file an issue\n ${e.getMessage}")
           e.printStackTrace()

--- a/src/main/scala/firrtl_interpreter/FirrtlRepl.scala
+++ b/src/main/scala/firrtl_interpreter/FirrtlRepl.scala
@@ -315,19 +315,14 @@ class FirrtlRepl(val optionsManager: ExecutionOptionsManager with HasReplConfig 
           ))
         }
         def run(args: Array[String]): Unit = {
-          currentScript match {
-            case Some(script) =>
-              getOneArg("firrtl_interpreter.vcd [fileName|done]",
-                argOption = Some("out.firrtl_interpreter.vcd")) match {
-                case Some("done")   =>
-                  interpreter.disableVCD()
-                case Some(fileName) =>
-                  interpreter.makeVCDLogger(fileName)
-                case _ =>
-                  interpreter.disableVCD()
-              }
+          getOneArg("firrtl_interpreter.vcd [fileName|done]",
+            argOption = Some("out.firrtl_interpreter.vcd")) match {
+            case Some("done")   =>
+              interpreter.disableVCD()
+            case Some(fileName) =>
+              interpreter.makeVCDLogger(fileName)
             case _ =>
-              error(s"No current script")
+              interpreter.disableVCD()
           }
         }
       },
@@ -1009,8 +1004,8 @@ class FirrtlRepl(val optionsManager: ExecutionOptionsManager with HasReplConfig 
         case ie: InterpreterException =>
           console.println(s"Interpreter Exception occurred: ${ie.getMessage}")
         case e: NullPointerException =>
-          error(s"repl error ${e.getMessage}")
-          done = true
+          error(s"Null pointer exception, please file an issue\n ${e.getMessage}")
+          e.printStackTrace()
         case e: Exception =>
           console.println(s"Exception occurred: ${e.getMessage}")
           e.printStackTrace()

--- a/src/test/resources/fft.fir
+++ b/src/test/resources/fft.fir
@@ -1,0 +1,5988 @@
+;buildInfoPackage: chisel3, version: 3.1-SNAPSHOT, scalaVersion: 2.11.7, sbtVersion: 0.13.11, builtAtString: 2016-12-02 01:10:49.782, builtAtMillis: 1480641049782
+circuit FFTUnpacked : 
+  extmodule BBFSubtract : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFSubtract
+    
+    
+  extmodule BBFSubtract_1 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFSubtract
+    
+    
+  extmodule BBFSubtract_2 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFSubtract
+    
+    
+  extmodule BBFSubtract_3 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFSubtract
+    
+    
+  extmodule BBFSubtract_4 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFSubtract
+    
+    
+  extmodule BBFSubtract_5 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFSubtract
+    
+    
+  extmodule BBFSubtract_6 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFSubtract
+    
+    
+  extmodule BBFMultiply : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFMultiply_1 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFSubtract_7 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFSubtract
+    
+    
+  extmodule BBFAdd : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFMultiply_2 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFMultiply_3 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFAdd_1 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFAdd_2 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFAdd_3 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFSubtract_8 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFSubtract
+    
+    
+  extmodule BBFSubtract_9 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFSubtract
+    
+    
+  extmodule BBFAdd_4 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFAdd_5 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFMultiply_4 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFMultiply_5 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFSubtract_10 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFSubtract
+    
+    
+  extmodule BBFAdd_6 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFMultiply_6 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFMultiply_7 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFAdd_7 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFAdd_8 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFAdd_9 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFSubtract_11 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFSubtract
+    
+    
+  extmodule BBFSubtract_12 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFSubtract
+    
+    
+  extmodule BBFAdd_10 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFAdd_11 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFMultiply_8 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFMultiply_9 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFSubtract_13 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFSubtract
+    
+    
+  extmodule BBFAdd_12 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFMultiply_10 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFMultiply_11 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFAdd_13 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFAdd_14 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFAdd_15 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFSubtract_14 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFSubtract
+    
+    
+  extmodule BBFSubtract_15 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFSubtract
+    
+    
+  extmodule BBFAdd_16 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFAdd_17 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFMultiply_12 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFMultiply_13 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFSubtract_16 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFSubtract
+    
+    
+  extmodule BBFAdd_18 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFMultiply_14 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFMultiply_15 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFAdd_19 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFAdd_20 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFAdd_21 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFSubtract_17 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFSubtract
+    
+    
+  extmodule BBFSubtract_18 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFSubtract
+    
+    
+  extmodule BBFAdd_22 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFAdd_23 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFMultiply_16 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFMultiply_17 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFSubtract_19 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFSubtract
+    
+    
+  extmodule BBFAdd_24 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFMultiply_18 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFMultiply_19 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFAdd_25 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFAdd_26 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFAdd_27 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFSubtract_20 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFSubtract
+    
+    
+  extmodule BBFSubtract_21 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFSubtract
+    
+    
+  extmodule BBFAdd_28 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFAdd_29 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFMultiply_20 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFMultiply_21 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFSubtract_22 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFSubtract
+    
+    
+  extmodule BBFAdd_30 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFMultiply_22 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFMultiply_23 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFAdd_31 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFAdd_32 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFAdd_33 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFSubtract_23 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFSubtract
+    
+    
+  extmodule BBFSubtract_24 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFSubtract
+    
+    
+  extmodule BBFAdd_34 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFAdd_35 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFMultiply_24 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFMultiply_25 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFSubtract_25 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFSubtract
+    
+    
+  extmodule BBFAdd_36 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFMultiply_26 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFMultiply_27 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFAdd_37 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFAdd_38 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFAdd_39 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFSubtract_26 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFSubtract
+    
+    
+  extmodule BBFSubtract_27 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFSubtract
+    
+    
+  extmodule BBFAdd_40 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFAdd_41 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFMultiply_28 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFMultiply_29 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFSubtract_28 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFSubtract
+    
+    
+  extmodule BBFAdd_42 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFMultiply_30 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFMultiply_31 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFAdd_43 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFAdd_44 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFAdd_45 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFSubtract_29 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFSubtract
+    
+    
+  extmodule BBFSubtract_30 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFSubtract
+    
+    
+  extmodule BBFAdd_46 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFAdd_47 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFMultiply_32 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFMultiply_33 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFSubtract_31 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFSubtract
+    
+    
+  extmodule BBFAdd_48 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFMultiply_34 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFMultiply_35 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFAdd_49 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFAdd_50 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFAdd_51 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFSubtract_32 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFSubtract
+    
+    
+  extmodule BBFSubtract_33 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFSubtract
+    
+    
+  extmodule BBFAdd_52 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFAdd_53 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFMultiply_36 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFMultiply_37 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFSubtract_34 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFSubtract
+    
+    
+  extmodule BBFAdd_54 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFMultiply_38 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFMultiply_39 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFAdd_55 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFAdd_56 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFAdd_57 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFSubtract_35 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFSubtract
+    
+    
+  extmodule BBFSubtract_36 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFSubtract
+    
+    
+  extmodule BBFAdd_58 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFAdd_59 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFMultiply_40 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFMultiply_41 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFSubtract_37 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFSubtract
+    
+    
+  extmodule BBFAdd_60 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFMultiply_42 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFMultiply_43 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFAdd_61 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFAdd_62 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFAdd_63 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFSubtract_38 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFSubtract
+    
+    
+  extmodule BBFSubtract_39 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFSubtract
+    
+    
+  extmodule BBFAdd_64 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFAdd_65 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFMultiply_44 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFMultiply_45 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFSubtract_40 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFSubtract
+    
+    
+  extmodule BBFAdd_66 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFMultiply_46 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFMultiply_47 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFAdd_67 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFAdd_68 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFAdd_69 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFSubtract_41 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFSubtract
+    
+    
+  extmodule BBFSubtract_42 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFSubtract
+    
+    
+  extmodule BBFAdd_70 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFAdd_71 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  module DirectFFT : 
+    input clock : Clock
+    input reset : UInt<1>
+    output io : {flip in : {valid : UInt<1>, bits : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[8], sync : UInt<1>}, out : {valid : UInt<1>, bits : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[8], sync : UInt<1>}}
+    
+    io is invalid
+    io is invalid
+    wire _T_5 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_5 is invalid @[DspReal.scala 165:19]
+    _T_5.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_12 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_12 is invalid @[DspReal.scala 165:19]
+    _T_12.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_316 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_316 is invalid @[DspReal.scala 165:19]
+    _T_316.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_323 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_323 is invalid @[DspReal.scala 165:19]
+    _T_323.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    node _T_624 = and(io.in.sync, io.in.valid) @[FFT.scala 32:66]
+    reg sync : UInt<1>, clock with : (reset => (reset, UInt<1>("h00"))) @[Counter.scala 15:29]
+    when io.in.valid : @[Counter.scala 59:17]
+      node _T_627 = eq(sync, UInt<1>("h01")) @[Counter.scala 23:24]
+      node _T_629 = add(sync, UInt<1>("h01")) @[Counter.scala 24:22]
+      node _T_630 = tail(_T_629, 1) @[Counter.scala 24:22]
+      sync <= _T_630 @[Counter.scala 24:13]
+      skip @[Counter.scala 59:17]
+    node _T_631 = and(io.in.valid, _T_627) @[Counter.scala 60:20]
+    when _T_624 : @[CounterWithReset.scala 11:31]
+      sync <= UInt<1>("h00") @[CounterWithReset.scala 11:38]
+      skip @[CounterWithReset.scala 11:31]
+    cmem _T_635 : UInt<1>[3] @[FFTUtilities.scala 169:21]
+    reg _T_637 : UInt<2>, clock with : (reset => (reset, UInt<2>("h00"))) @[Counter.scala 15:29]
+    when io.in.valid : @[Counter.scala 59:17]
+      node _T_639 = eq(_T_637, UInt<2>("h02")) @[Counter.scala 23:24]
+      node _T_641 = add(_T_637, UInt<1>("h01")) @[Counter.scala 24:22]
+      node _T_642 = tail(_T_641, 1) @[Counter.scala 24:22]
+      _T_637 <= _T_642 @[Counter.scala 24:13]
+      when _T_639 : @[Counter.scala 26:21]
+        _T_637 <= UInt<1>("h00") @[Counter.scala 26:29]
+        skip @[Counter.scala 26:21]
+      skip @[Counter.scala 59:17]
+    node _T_644 = and(io.in.valid, _T_639) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_645 = _T_635[_T_637], clock
+      _T_645 <= io.in.sync @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_646 = _T_635[_T_637], clock
+    io.out.sync <= _T_646 @[FFT.scala 33:15]
+    io.out.valid <= io.in.valid @[FFT.scala 34:16]
+    wire _T_650 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_650 is invalid @[DspReal.scala 165:19]
+    _T_650.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_657 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_657 is invalid @[DspReal.scala 165:19]
+    _T_657.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire twiddle_rom : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[4] @[FFT.scala 39:25]
+    twiddle_rom is invalid @[FFT.scala 39:25]
+    wire _T_734 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_734 is invalid @[DspReal.scala 165:19]
+    _T_734.node <= UInt<64>("h03ff0000000000000") @[DspReal.scala 166:14]
+    wire _T_741 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_741 is invalid @[DspReal.scala 165:19]
+    _T_741.node <= UInt<64>("h08000000000000000") @[DspReal.scala 166:14]
+    wire _T_758 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_758 is invalid @[DspComplex.scala 14:22]
+    _T_758.real.node <= _T_734.node @[DspComplex.scala 15:17]
+    _T_758.imaginary.node <= _T_741.node @[DspComplex.scala 16:22]
+    twiddle_rom[0].imaginary.node <= _T_758.imaginary.node @[FFT.scala 40:69]
+    twiddle_rom[0].real.node <= _T_758.real.node @[FFT.scala 40:69]
+    wire _T_762 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_762 is invalid @[DspReal.scala 165:19]
+    _T_762.node <= UInt<64>("h03fed906bcf328d46") @[DspReal.scala 166:14]
+    wire _T_769 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_769 is invalid @[DspReal.scala 165:19]
+    _T_769.node <= UInt<64>("h0bfd87de2a6aea963") @[DspReal.scala 166:14]
+    wire _T_786 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_786 is invalid @[DspComplex.scala 14:22]
+    _T_786.real.node <= _T_762.node @[DspComplex.scala 15:17]
+    _T_786.imaginary.node <= _T_769.node @[DspComplex.scala 16:22]
+    twiddle_rom[1].imaginary.node <= _T_786.imaginary.node @[FFT.scala 40:69]
+    twiddle_rom[1].real.node <= _T_786.real.node @[FFT.scala 40:69]
+    wire _T_790 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_790 is invalid @[DspReal.scala 165:19]
+    _T_790.node <= UInt<64>("h03fe6a09e667f3bcd") @[DspReal.scala 166:14]
+    wire _T_797 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_797 is invalid @[DspReal.scala 165:19]
+    _T_797.node <= UInt<64>("h0bfe6a09e667f3bcc") @[DspReal.scala 166:14]
+    wire _T_814 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_814 is invalid @[DspComplex.scala 14:22]
+    _T_814.real.node <= _T_790.node @[DspComplex.scala 15:17]
+    _T_814.imaginary.node <= _T_797.node @[DspComplex.scala 16:22]
+    twiddle_rom[2].imaginary.node <= _T_814.imaginary.node @[FFT.scala 40:69]
+    twiddle_rom[2].real.node <= _T_814.real.node @[FFT.scala 40:69]
+    wire _T_818 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_818 is invalid @[DspReal.scala 165:19]
+    _T_818.node <= UInt<64>("h03fd87de2a6aea964") @[DspReal.scala 166:14]
+    wire _T_825 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_825 is invalid @[DspReal.scala 165:19]
+    _T_825.node <= UInt<64>("h0bfed906bcf328d46") @[DspReal.scala 166:14]
+    wire _T_842 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_842 is invalid @[DspComplex.scala 14:22]
+    _T_842.real.node <= _T_818.node @[DspComplex.scala 15:17]
+    _T_842.imaginary.node <= _T_825.node @[DspComplex.scala 16:22]
+    twiddle_rom[3].imaginary.node <= _T_842.imaginary.node @[FFT.scala 40:69]
+    twiddle_rom[3].real.node <= _T_842.real.node @[FFT.scala 40:69]
+    wire indices_rom : UInt<3>[14] @[FFT.scala 41:24]
+    indices_rom is invalid @[FFT.scala 41:24]
+    indices_rom[0] <= UInt<1>("h00") @[FFT.scala 41:24]
+    indices_rom[1] <= UInt<1>("h00") @[FFT.scala 41:24]
+    indices_rom[2] <= UInt<1>("h00") @[FFT.scala 41:24]
+    indices_rom[3] <= UInt<3>("h04") @[FFT.scala 41:24]
+    indices_rom[4] <= UInt<3>("h04") @[FFT.scala 41:24]
+    indices_rom[5] <= UInt<2>("h02") @[FFT.scala 41:24]
+    indices_rom[6] <= UInt<3>("h06") @[FFT.scala 41:24]
+    indices_rom[7] <= UInt<3>("h04") @[FFT.scala 41:24]
+    indices_rom[8] <= UInt<2>("h02") @[FFT.scala 41:24]
+    indices_rom[9] <= UInt<1>("h01") @[FFT.scala 41:24]
+    indices_rom[10] <= UInt<3>("h05") @[FFT.scala 41:24]
+    indices_rom[11] <= UInt<3>("h06") @[FFT.scala 41:24]
+    indices_rom[12] <= UInt<2>("h03") @[FFT.scala 41:24]
+    indices_rom[13] <= UInt<3>("h07") @[FFT.scala 41:24]
+    node start = mul(sync, UInt<3>("h07")) @[FFT.scala 43:19]
+    wire _T_894 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_894 is invalid @[DspReal.scala 165:19]
+    _T_894.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_901 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_901 is invalid @[DspReal.scala 165:19]
+    _T_901.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_918 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 44:42]
+    _T_918 is invalid @[FFT.scala 44:42]
+    wire _T_922 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_922 is invalid @[DspReal.scala 165:19]
+    _T_922.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_929 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_929 is invalid @[DspReal.scala 165:19]
+    _T_929.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_946 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 44:42]
+    _T_946 is invalid @[FFT.scala 44:42]
+    wire _T_950 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_950 is invalid @[DspReal.scala 165:19]
+    _T_950.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_957 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_957 is invalid @[DspReal.scala 165:19]
+    _T_957.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_974 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 44:42]
+    _T_974 is invalid @[FFT.scala 44:42]
+    wire _T_978 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_978 is invalid @[DspReal.scala 165:19]
+    _T_978.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_985 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_985 is invalid @[DspReal.scala 165:19]
+    _T_985.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_1002 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 44:42]
+    _T_1002 is invalid @[FFT.scala 44:42]
+    wire _T_1006 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1006 is invalid @[DspReal.scala 165:19]
+    _T_1006.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_1013 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1013 is invalid @[DspReal.scala 165:19]
+    _T_1013.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_1030 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 44:42]
+    _T_1030 is invalid @[FFT.scala 44:42]
+    wire _T_1034 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1034 is invalid @[DspReal.scala 165:19]
+    _T_1034.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_1041 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1041 is invalid @[DspReal.scala 165:19]
+    _T_1041.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_1058 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 44:42]
+    _T_1058 is invalid @[FFT.scala 44:42]
+    wire _T_1062 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1062 is invalid @[DspReal.scala 165:19]
+    _T_1062.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_1069 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1069 is invalid @[DspReal.scala 165:19]
+    _T_1069.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_1086 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 44:42]
+    _T_1086 is invalid @[FFT.scala 44:42]
+    wire twiddle : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[7] @[FFT.scala 44:37]
+    twiddle is invalid @[FFT.scala 44:37]
+    twiddle[0].imaginary.node <= _T_918.imaginary.node @[FFT.scala 44:37]
+    twiddle[0].real.node <= _T_918.real.node @[FFT.scala 44:37]
+    twiddle[1].imaginary.node <= _T_946.imaginary.node @[FFT.scala 44:37]
+    twiddle[1].real.node <= _T_946.real.node @[FFT.scala 44:37]
+    twiddle[2].imaginary.node <= _T_974.imaginary.node @[FFT.scala 44:37]
+    twiddle[2].real.node <= _T_974.real.node @[FFT.scala 44:37]
+    twiddle[3].imaginary.node <= _T_1002.imaginary.node @[FFT.scala 44:37]
+    twiddle[3].real.node <= _T_1002.real.node @[FFT.scala 44:37]
+    twiddle[4].imaginary.node <= _T_1030.imaginary.node @[FFT.scala 44:37]
+    twiddle[4].real.node <= _T_1030.real.node @[FFT.scala 44:37]
+    twiddle[5].imaginary.node <= _T_1058.imaginary.node @[FFT.scala 44:37]
+    twiddle[5].real.node <= _T_1058.real.node @[FFT.scala 44:37]
+    twiddle[6].imaginary.node <= _T_1086.imaginary.node @[FFT.scala 44:37]
+    twiddle[6].real.node <= _T_1086.real.node @[FFT.scala 44:37]
+    node _T_1299 = add(start, UInt<1>("h00")) @[FFT.scala 49:67]
+    node _T_1300 = tail(_T_1299, 1) @[FFT.scala 49:67]
+    node _T_1302 = bits(indices_rom[_T_1300], 2, 2) @[FFT.scala 49:76]
+    node _T_1304 = add(start, UInt<1>("h00")) @[FFT.scala 49:150]
+    node _T_1305 = tail(_T_1304, 1) @[FFT.scala 49:150]
+    node _T_1307 = bits(indices_rom[_T_1305], 1, 0) @[FFT.scala 49:159]
+    wire _T_1317 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1317 is invalid @[DspReal.scala 165:19]
+    _T_1317.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    inst BBFSubtract_43 of BBFSubtract @[DspReal.scala 102:36]
+    BBFSubtract_43.out is invalid
+    BBFSubtract_43.in2 is invalid
+    BBFSubtract_43.in1 is invalid
+    BBFSubtract_43.in1 <= _T_1317.node @[DspReal.scala 81:21]
+    BBFSubtract_43.in2 <= twiddle_rom[_T_1307].real.node @[DspReal.scala 82:21]
+    wire _T_1324 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_1324 is invalid @[DspReal.scala 83:19]
+    _T_1324.node <= BBFSubtract_43.out @[DspReal.scala 84:14]
+    wire _T_1340 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_1340 is invalid @[DspComplex.scala 14:22]
+    _T_1340.real.node <= twiddle_rom[_T_1307].imaginary.node @[DspComplex.scala 15:17]
+    _T_1340.imaginary.node <= _T_1324.node @[DspComplex.scala 16:22]
+    node _T_1342 = add(start, UInt<1>("h00")) @[FFT.scala 49:219]
+    node _T_1343 = tail(_T_1342, 1) @[FFT.scala 49:219]
+    node _T_1351 = bits(indices_rom[_T_1343], 1, 0)
+    node _T_1358 = mux(_T_1302, _T_1340, twiddle_rom[_T_1351]) @[FFT.scala 49:49]
+    node _T_1360 = add(start, UInt<1>("h01")) @[FFT.scala 49:67]
+    node _T_1361 = tail(_T_1360, 1) @[FFT.scala 49:67]
+    node _T_1363 = bits(indices_rom[_T_1361], 2, 2) @[FFT.scala 49:76]
+    node _T_1365 = add(start, UInt<1>("h01")) @[FFT.scala 49:150]
+    node _T_1366 = tail(_T_1365, 1) @[FFT.scala 49:150]
+    node _T_1368 = bits(indices_rom[_T_1366], 1, 0) @[FFT.scala 49:159]
+    wire _T_1378 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1378 is invalid @[DspReal.scala 165:19]
+    _T_1378.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    inst BBFSubtract_1_1 of BBFSubtract_1 @[DspReal.scala 102:36]
+    BBFSubtract_1_1.out is invalid
+    BBFSubtract_1_1.in2 is invalid
+    BBFSubtract_1_1.in1 is invalid
+    BBFSubtract_1_1.in1 <= _T_1378.node @[DspReal.scala 81:21]
+    BBFSubtract_1_1.in2 <= twiddle_rom[_T_1368].real.node @[DspReal.scala 82:21]
+    wire _T_1385 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_1385 is invalid @[DspReal.scala 83:19]
+    _T_1385.node <= BBFSubtract_1_1.out @[DspReal.scala 84:14]
+    wire _T_1401 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_1401 is invalid @[DspComplex.scala 14:22]
+    _T_1401.real.node <= twiddle_rom[_T_1368].imaginary.node @[DspComplex.scala 15:17]
+    _T_1401.imaginary.node <= _T_1385.node @[DspComplex.scala 16:22]
+    node _T_1403 = add(start, UInt<1>("h01")) @[FFT.scala 49:219]
+    node _T_1404 = tail(_T_1403, 1) @[FFT.scala 49:219]
+    node _T_1412 = bits(indices_rom[_T_1404], 1, 0)
+    node _T_1419 = mux(_T_1363, _T_1401, twiddle_rom[_T_1412]) @[FFT.scala 49:49]
+    node _T_1421 = add(start, UInt<2>("h02")) @[FFT.scala 49:67]
+    node _T_1422 = tail(_T_1421, 1) @[FFT.scala 49:67]
+    node _T_1424 = bits(indices_rom[_T_1422], 2, 2) @[FFT.scala 49:76]
+    node _T_1426 = add(start, UInt<2>("h02")) @[FFT.scala 49:150]
+    node _T_1427 = tail(_T_1426, 1) @[FFT.scala 49:150]
+    node _T_1429 = bits(indices_rom[_T_1427], 1, 0) @[FFT.scala 49:159]
+    wire _T_1439 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1439 is invalid @[DspReal.scala 165:19]
+    _T_1439.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    inst BBFSubtract_2_1 of BBFSubtract_2 @[DspReal.scala 102:36]
+    BBFSubtract_2_1.out is invalid
+    BBFSubtract_2_1.in2 is invalid
+    BBFSubtract_2_1.in1 is invalid
+    BBFSubtract_2_1.in1 <= _T_1439.node @[DspReal.scala 81:21]
+    BBFSubtract_2_1.in2 <= twiddle_rom[_T_1429].real.node @[DspReal.scala 82:21]
+    wire _T_1446 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_1446 is invalid @[DspReal.scala 83:19]
+    _T_1446.node <= BBFSubtract_2_1.out @[DspReal.scala 84:14]
+    wire _T_1462 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_1462 is invalid @[DspComplex.scala 14:22]
+    _T_1462.real.node <= twiddle_rom[_T_1429].imaginary.node @[DspComplex.scala 15:17]
+    _T_1462.imaginary.node <= _T_1446.node @[DspComplex.scala 16:22]
+    node _T_1464 = add(start, UInt<2>("h02")) @[FFT.scala 49:219]
+    node _T_1465 = tail(_T_1464, 1) @[FFT.scala 49:219]
+    node _T_1473 = bits(indices_rom[_T_1465], 1, 0)
+    node _T_1480 = mux(_T_1424, _T_1462, twiddle_rom[_T_1473]) @[FFT.scala 49:49]
+    node _T_1482 = add(start, UInt<2>("h03")) @[FFT.scala 49:67]
+    node _T_1483 = tail(_T_1482, 1) @[FFT.scala 49:67]
+    node _T_1485 = bits(indices_rom[_T_1483], 2, 2) @[FFT.scala 49:76]
+    node _T_1487 = add(start, UInt<2>("h03")) @[FFT.scala 49:150]
+    node _T_1488 = tail(_T_1487, 1) @[FFT.scala 49:150]
+    node _T_1490 = bits(indices_rom[_T_1488], 1, 0) @[FFT.scala 49:159]
+    wire _T_1500 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1500 is invalid @[DspReal.scala 165:19]
+    _T_1500.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    inst BBFSubtract_3_1 of BBFSubtract_3 @[DspReal.scala 102:36]
+    BBFSubtract_3_1.out is invalid
+    BBFSubtract_3_1.in2 is invalid
+    BBFSubtract_3_1.in1 is invalid
+    BBFSubtract_3_1.in1 <= _T_1500.node @[DspReal.scala 81:21]
+    BBFSubtract_3_1.in2 <= twiddle_rom[_T_1490].real.node @[DspReal.scala 82:21]
+    wire _T_1507 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_1507 is invalid @[DspReal.scala 83:19]
+    _T_1507.node <= BBFSubtract_3_1.out @[DspReal.scala 84:14]
+    wire _T_1523 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_1523 is invalid @[DspComplex.scala 14:22]
+    _T_1523.real.node <= twiddle_rom[_T_1490].imaginary.node @[DspComplex.scala 15:17]
+    _T_1523.imaginary.node <= _T_1507.node @[DspComplex.scala 16:22]
+    node _T_1525 = add(start, UInt<2>("h03")) @[FFT.scala 49:219]
+    node _T_1526 = tail(_T_1525, 1) @[FFT.scala 49:219]
+    node _T_1534 = bits(indices_rom[_T_1526], 1, 0)
+    node _T_1541 = mux(_T_1485, _T_1523, twiddle_rom[_T_1534]) @[FFT.scala 49:49]
+    node _T_1543 = add(start, UInt<3>("h04")) @[FFT.scala 49:67]
+    node _T_1544 = tail(_T_1543, 1) @[FFT.scala 49:67]
+    node _T_1546 = bits(indices_rom[_T_1544], 2, 2) @[FFT.scala 49:76]
+    node _T_1548 = add(start, UInt<3>("h04")) @[FFT.scala 49:150]
+    node _T_1549 = tail(_T_1548, 1) @[FFT.scala 49:150]
+    node _T_1551 = bits(indices_rom[_T_1549], 1, 0) @[FFT.scala 49:159]
+    wire _T_1561 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1561 is invalid @[DspReal.scala 165:19]
+    _T_1561.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    inst BBFSubtract_4_1 of BBFSubtract_4 @[DspReal.scala 102:36]
+    BBFSubtract_4_1.out is invalid
+    BBFSubtract_4_1.in2 is invalid
+    BBFSubtract_4_1.in1 is invalid
+    BBFSubtract_4_1.in1 <= _T_1561.node @[DspReal.scala 81:21]
+    BBFSubtract_4_1.in2 <= twiddle_rom[_T_1551].real.node @[DspReal.scala 82:21]
+    wire _T_1568 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_1568 is invalid @[DspReal.scala 83:19]
+    _T_1568.node <= BBFSubtract_4_1.out @[DspReal.scala 84:14]
+    wire _T_1584 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_1584 is invalid @[DspComplex.scala 14:22]
+    _T_1584.real.node <= twiddle_rom[_T_1551].imaginary.node @[DspComplex.scala 15:17]
+    _T_1584.imaginary.node <= _T_1568.node @[DspComplex.scala 16:22]
+    node _T_1586 = add(start, UInt<3>("h04")) @[FFT.scala 49:219]
+    node _T_1587 = tail(_T_1586, 1) @[FFT.scala 49:219]
+    node _T_1595 = bits(indices_rom[_T_1587], 1, 0)
+    node _T_1602 = mux(_T_1546, _T_1584, twiddle_rom[_T_1595]) @[FFT.scala 49:49]
+    node _T_1604 = add(start, UInt<3>("h05")) @[FFT.scala 49:67]
+    node _T_1605 = tail(_T_1604, 1) @[FFT.scala 49:67]
+    node _T_1607 = bits(indices_rom[_T_1605], 2, 2) @[FFT.scala 49:76]
+    node _T_1609 = add(start, UInt<3>("h05")) @[FFT.scala 49:150]
+    node _T_1610 = tail(_T_1609, 1) @[FFT.scala 49:150]
+    node _T_1612 = bits(indices_rom[_T_1610], 1, 0) @[FFT.scala 49:159]
+    wire _T_1622 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1622 is invalid @[DspReal.scala 165:19]
+    _T_1622.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    inst BBFSubtract_5_1 of BBFSubtract_5 @[DspReal.scala 102:36]
+    BBFSubtract_5_1.out is invalid
+    BBFSubtract_5_1.in2 is invalid
+    BBFSubtract_5_1.in1 is invalid
+    BBFSubtract_5_1.in1 <= _T_1622.node @[DspReal.scala 81:21]
+    BBFSubtract_5_1.in2 <= twiddle_rom[_T_1612].real.node @[DspReal.scala 82:21]
+    wire _T_1629 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_1629 is invalid @[DspReal.scala 83:19]
+    _T_1629.node <= BBFSubtract_5_1.out @[DspReal.scala 84:14]
+    wire _T_1645 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_1645 is invalid @[DspComplex.scala 14:22]
+    _T_1645.real.node <= twiddle_rom[_T_1612].imaginary.node @[DspComplex.scala 15:17]
+    _T_1645.imaginary.node <= _T_1629.node @[DspComplex.scala 16:22]
+    node _T_1647 = add(start, UInt<3>("h05")) @[FFT.scala 49:219]
+    node _T_1648 = tail(_T_1647, 1) @[FFT.scala 49:219]
+    node _T_1656 = bits(indices_rom[_T_1648], 1, 0)
+    node _T_1663 = mux(_T_1607, _T_1645, twiddle_rom[_T_1656]) @[FFT.scala 49:49]
+    node _T_1665 = add(start, UInt<3>("h06")) @[FFT.scala 49:67]
+    node _T_1666 = tail(_T_1665, 1) @[FFT.scala 49:67]
+    node _T_1668 = bits(indices_rom[_T_1666], 2, 2) @[FFT.scala 49:76]
+    node _T_1670 = add(start, UInt<3>("h06")) @[FFT.scala 49:150]
+    node _T_1671 = tail(_T_1670, 1) @[FFT.scala 49:150]
+    node _T_1673 = bits(indices_rom[_T_1671], 1, 0) @[FFT.scala 49:159]
+    wire _T_1683 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1683 is invalid @[DspReal.scala 165:19]
+    _T_1683.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    inst BBFSubtract_6_1 of BBFSubtract_6 @[DspReal.scala 102:36]
+    BBFSubtract_6_1.out is invalid
+    BBFSubtract_6_1.in2 is invalid
+    BBFSubtract_6_1.in1 is invalid
+    BBFSubtract_6_1.in1 <= _T_1683.node @[DspReal.scala 81:21]
+    BBFSubtract_6_1.in2 <= twiddle_rom[_T_1673].real.node @[DspReal.scala 82:21]
+    wire _T_1690 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_1690 is invalid @[DspReal.scala 83:19]
+    _T_1690.node <= BBFSubtract_6_1.out @[DspReal.scala 84:14]
+    wire _T_1706 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_1706 is invalid @[DspComplex.scala 14:22]
+    _T_1706.real.node <= twiddle_rom[_T_1673].imaginary.node @[DspComplex.scala 15:17]
+    _T_1706.imaginary.node <= _T_1690.node @[DspComplex.scala 16:22]
+    node _T_1708 = add(start, UInt<3>("h06")) @[FFT.scala 49:219]
+    node _T_1709 = tail(_T_1708, 1) @[FFT.scala 49:219]
+    node _T_1717 = bits(indices_rom[_T_1709], 1, 0)
+    node _T_1724 = mux(_T_1668, _T_1706, twiddle_rom[_T_1717]) @[FFT.scala 49:49]
+    twiddle[0].imaginary.node <= _T_1358.imaginary.node @[FFT.scala 49:13]
+    twiddle[0].real.node <= _T_1358.real.node @[FFT.scala 49:13]
+    twiddle[1].imaginary.node <= _T_1419.imaginary.node @[FFT.scala 49:13]
+    twiddle[1].real.node <= _T_1419.real.node @[FFT.scala 49:13]
+    twiddle[2].imaginary.node <= _T_1480.imaginary.node @[FFT.scala 49:13]
+    twiddle[2].real.node <= _T_1480.real.node @[FFT.scala 49:13]
+    twiddle[3].imaginary.node <= _T_1541.imaginary.node @[FFT.scala 49:13]
+    twiddle[3].real.node <= _T_1541.real.node @[FFT.scala 49:13]
+    twiddle[4].imaginary.node <= _T_1602.imaginary.node @[FFT.scala 49:13]
+    twiddle[4].real.node <= _T_1602.real.node @[FFT.scala 49:13]
+    twiddle[5].imaginary.node <= _T_1663.imaginary.node @[FFT.scala 49:13]
+    twiddle[5].real.node <= _T_1663.real.node @[FFT.scala 49:13]
+    twiddle[6].imaginary.node <= _T_1724.imaginary.node @[FFT.scala 49:13]
+    twiddle[6].real.node <= _T_1724.real.node @[FFT.scala 49:13]
+    wire _T_1728 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1728 is invalid @[DspReal.scala 165:19]
+    _T_1728.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_1735 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1735 is invalid @[DspReal.scala 165:19]
+    _T_1735.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire stage_outputs_0_0 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 54:77]
+    stage_outputs_0_0 is invalid @[FFT.scala 54:77]
+    wire _T_1755 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1755 is invalid @[DspReal.scala 165:19]
+    _T_1755.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_1762 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1762 is invalid @[DspReal.scala 165:19]
+    _T_1762.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire stage_outputs_0_1 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 54:77]
+    stage_outputs_0_1 is invalid @[FFT.scala 54:77]
+    wire _T_1782 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1782 is invalid @[DspReal.scala 165:19]
+    _T_1782.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_1789 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1789 is invalid @[DspReal.scala 165:19]
+    _T_1789.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire stage_outputs_0_2 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 54:77]
+    stage_outputs_0_2 is invalid @[FFT.scala 54:77]
+    wire _T_1809 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1809 is invalid @[DspReal.scala 165:19]
+    _T_1809.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_1816 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1816 is invalid @[DspReal.scala 165:19]
+    _T_1816.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire stage_outputs_0_3 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 54:77]
+    stage_outputs_0_3 is invalid @[FFT.scala 54:77]
+    wire _T_1836 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1836 is invalid @[DspReal.scala 165:19]
+    _T_1836.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_1843 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1843 is invalid @[DspReal.scala 165:19]
+    _T_1843.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire stage_outputs_0_4 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 54:77]
+    stage_outputs_0_4 is invalid @[FFT.scala 54:77]
+    wire _T_1863 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1863 is invalid @[DspReal.scala 165:19]
+    _T_1863.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_1870 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1870 is invalid @[DspReal.scala 165:19]
+    _T_1870.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire stage_outputs_0_5 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 54:77]
+    stage_outputs_0_5 is invalid @[FFT.scala 54:77]
+    wire _T_1890 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1890 is invalid @[DspReal.scala 165:19]
+    _T_1890.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_1897 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1897 is invalid @[DspReal.scala 165:19]
+    _T_1897.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire stage_outputs_0_6 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 54:77]
+    stage_outputs_0_6 is invalid @[FFT.scala 54:77]
+    wire _T_1917 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1917 is invalid @[DspReal.scala 165:19]
+    _T_1917.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_1924 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1924 is invalid @[DspReal.scala 165:19]
+    _T_1924.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire stage_outputs_0_7 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 54:77]
+    stage_outputs_0_7 is invalid @[FFT.scala 54:77]
+    wire _T_1944 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1944 is invalid @[DspReal.scala 165:19]
+    _T_1944.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_1951 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1951 is invalid @[DspReal.scala 165:19]
+    _T_1951.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire stage_outputs_1_0 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 54:77]
+    stage_outputs_1_0 is invalid @[FFT.scala 54:77]
+    wire _T_1971 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1971 is invalid @[DspReal.scala 165:19]
+    _T_1971.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_1978 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1978 is invalid @[DspReal.scala 165:19]
+    _T_1978.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire stage_outputs_1_1 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 54:77]
+    stage_outputs_1_1 is invalid @[FFT.scala 54:77]
+    wire _T_1998 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1998 is invalid @[DspReal.scala 165:19]
+    _T_1998.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_2005 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_2005 is invalid @[DspReal.scala 165:19]
+    _T_2005.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire stage_outputs_1_2 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 54:77]
+    stage_outputs_1_2 is invalid @[FFT.scala 54:77]
+    wire _T_2025 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_2025 is invalid @[DspReal.scala 165:19]
+    _T_2025.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_2032 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_2032 is invalid @[DspReal.scala 165:19]
+    _T_2032.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire stage_outputs_1_3 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 54:77]
+    stage_outputs_1_3 is invalid @[FFT.scala 54:77]
+    wire _T_2052 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_2052 is invalid @[DspReal.scala 165:19]
+    _T_2052.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_2059 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_2059 is invalid @[DspReal.scala 165:19]
+    _T_2059.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire stage_outputs_1_4 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 54:77]
+    stage_outputs_1_4 is invalid @[FFT.scala 54:77]
+    wire _T_2079 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_2079 is invalid @[DspReal.scala 165:19]
+    _T_2079.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_2086 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_2086 is invalid @[DspReal.scala 165:19]
+    _T_2086.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire stage_outputs_1_5 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 54:77]
+    stage_outputs_1_5 is invalid @[FFT.scala 54:77]
+    wire _T_2106 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_2106 is invalid @[DspReal.scala 165:19]
+    _T_2106.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_2113 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_2113 is invalid @[DspReal.scala 165:19]
+    _T_2113.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire stage_outputs_1_6 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 54:77]
+    stage_outputs_1_6 is invalid @[FFT.scala 54:77]
+    wire _T_2133 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_2133 is invalid @[DspReal.scala 165:19]
+    _T_2133.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_2140 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_2140 is invalid @[DspReal.scala 165:19]
+    _T_2140.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire stage_outputs_1_7 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 54:77]
+    stage_outputs_1_7 is invalid @[FFT.scala 54:77]
+    wire _T_2160 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_2160 is invalid @[DspReal.scala 165:19]
+    _T_2160.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_2167 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_2167 is invalid @[DspReal.scala 165:19]
+    _T_2167.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire stage_outputs_2_0 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 54:77]
+    stage_outputs_2_0 is invalid @[FFT.scala 54:77]
+    wire _T_2187 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_2187 is invalid @[DspReal.scala 165:19]
+    _T_2187.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_2194 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_2194 is invalid @[DspReal.scala 165:19]
+    _T_2194.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire stage_outputs_2_1 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 54:77]
+    stage_outputs_2_1 is invalid @[FFT.scala 54:77]
+    wire _T_2214 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_2214 is invalid @[DspReal.scala 165:19]
+    _T_2214.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_2221 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_2221 is invalid @[DspReal.scala 165:19]
+    _T_2221.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire stage_outputs_2_2 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 54:77]
+    stage_outputs_2_2 is invalid @[FFT.scala 54:77]
+    wire _T_2241 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_2241 is invalid @[DspReal.scala 165:19]
+    _T_2241.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_2248 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_2248 is invalid @[DspReal.scala 165:19]
+    _T_2248.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire stage_outputs_2_3 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 54:77]
+    stage_outputs_2_3 is invalid @[FFT.scala 54:77]
+    wire _T_2268 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_2268 is invalid @[DspReal.scala 165:19]
+    _T_2268.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_2275 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_2275 is invalid @[DspReal.scala 165:19]
+    _T_2275.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire stage_outputs_2_4 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 54:77]
+    stage_outputs_2_4 is invalid @[FFT.scala 54:77]
+    wire _T_2295 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_2295 is invalid @[DspReal.scala 165:19]
+    _T_2295.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_2302 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_2302 is invalid @[DspReal.scala 165:19]
+    _T_2302.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire stage_outputs_2_5 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 54:77]
+    stage_outputs_2_5 is invalid @[FFT.scala 54:77]
+    wire _T_2322 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_2322 is invalid @[DspReal.scala 165:19]
+    _T_2322.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_2329 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_2329 is invalid @[DspReal.scala 165:19]
+    _T_2329.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire stage_outputs_2_6 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 54:77]
+    stage_outputs_2_6 is invalid @[FFT.scala 54:77]
+    wire _T_2349 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_2349 is invalid @[DspReal.scala 165:19]
+    _T_2349.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_2356 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_2356 is invalid @[DspReal.scala 165:19]
+    _T_2356.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire stage_outputs_2_7 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 54:77]
+    stage_outputs_2_7 is invalid @[FFT.scala 54:77]
+    wire _T_2376 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_2376 is invalid @[DspReal.scala 165:19]
+    _T_2376.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_2383 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_2383 is invalid @[DspReal.scala 165:19]
+    _T_2383.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire stage_outputs_3_0 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 54:77]
+    stage_outputs_3_0 is invalid @[FFT.scala 54:77]
+    wire _T_2403 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_2403 is invalid @[DspReal.scala 165:19]
+    _T_2403.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_2410 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_2410 is invalid @[DspReal.scala 165:19]
+    _T_2410.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire stage_outputs_3_1 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 54:77]
+    stage_outputs_3_1 is invalid @[FFT.scala 54:77]
+    wire _T_2430 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_2430 is invalid @[DspReal.scala 165:19]
+    _T_2430.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_2437 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_2437 is invalid @[DspReal.scala 165:19]
+    _T_2437.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire stage_outputs_3_2 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 54:77]
+    stage_outputs_3_2 is invalid @[FFT.scala 54:77]
+    wire _T_2457 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_2457 is invalid @[DspReal.scala 165:19]
+    _T_2457.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_2464 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_2464 is invalid @[DspReal.scala 165:19]
+    _T_2464.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire stage_outputs_3_3 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 54:77]
+    stage_outputs_3_3 is invalid @[FFT.scala 54:77]
+    wire _T_2484 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_2484 is invalid @[DspReal.scala 165:19]
+    _T_2484.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_2491 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_2491 is invalid @[DspReal.scala 165:19]
+    _T_2491.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire stage_outputs_3_4 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 54:77]
+    stage_outputs_3_4 is invalid @[FFT.scala 54:77]
+    wire _T_2511 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_2511 is invalid @[DspReal.scala 165:19]
+    _T_2511.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_2518 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_2518 is invalid @[DspReal.scala 165:19]
+    _T_2518.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire stage_outputs_3_5 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 54:77]
+    stage_outputs_3_5 is invalid @[FFT.scala 54:77]
+    wire _T_2538 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_2538 is invalid @[DspReal.scala 165:19]
+    _T_2538.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_2545 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_2545 is invalid @[DspReal.scala 165:19]
+    _T_2545.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire stage_outputs_3_6 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 54:77]
+    stage_outputs_3_6 is invalid @[FFT.scala 54:77]
+    wire _T_2565 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_2565 is invalid @[DspReal.scala 165:19]
+    _T_2565.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_2572 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_2572 is invalid @[DspReal.scala 165:19]
+    _T_2572.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire stage_outputs_3_7 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 54:77]
+    stage_outputs_3_7 is invalid @[FFT.scala 54:77]
+    stage_outputs_0_0.imaginary.node <= io.in.bits[0].imaginary.node @[FFT.scala 55:67]
+    stage_outputs_0_0.real.node <= io.in.bits[0].real.node @[FFT.scala 55:67]
+    stage_outputs_0_1.imaginary.node <= io.in.bits[1].imaginary.node @[FFT.scala 55:67]
+    stage_outputs_0_1.real.node <= io.in.bits[1].real.node @[FFT.scala 55:67]
+    stage_outputs_0_2.imaginary.node <= io.in.bits[2].imaginary.node @[FFT.scala 55:67]
+    stage_outputs_0_2.real.node <= io.in.bits[2].real.node @[FFT.scala 55:67]
+    stage_outputs_0_3.imaginary.node <= io.in.bits[3].imaginary.node @[FFT.scala 55:67]
+    stage_outputs_0_3.real.node <= io.in.bits[3].real.node @[FFT.scala 55:67]
+    stage_outputs_0_4.imaginary.node <= io.in.bits[4].imaginary.node @[FFT.scala 55:67]
+    stage_outputs_0_4.real.node <= io.in.bits[4].real.node @[FFT.scala 55:67]
+    stage_outputs_0_5.imaginary.node <= io.in.bits[5].imaginary.node @[FFT.scala 55:67]
+    stage_outputs_0_5.real.node <= io.in.bits[5].real.node @[FFT.scala 55:67]
+    stage_outputs_0_6.imaginary.node <= io.in.bits[6].imaginary.node @[FFT.scala 55:67]
+    stage_outputs_0_6.real.node <= io.in.bits[6].real.node @[FFT.scala 55:67]
+    stage_outputs_0_7.imaginary.node <= io.in.bits[7].imaginary.node @[FFT.scala 55:67]
+    stage_outputs_0_7.real.node <= io.in.bits[7].real.node @[FFT.scala 55:67]
+    inst BBFMultiply_48 of BBFMultiply @[DspReal.scala 106:36]
+    BBFMultiply_48.out is invalid
+    BBFMultiply_48.in2 is invalid
+    BBFMultiply_48.in1 is invalid
+    BBFMultiply_48.in1 <= stage_outputs_0_4.real.node @[DspReal.scala 81:21]
+    BBFMultiply_48.in2 <= twiddle[0].real.node @[DspReal.scala 82:21]
+    wire _T_2592 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_2592 is invalid @[DspReal.scala 83:19]
+    _T_2592.node <= BBFMultiply_48.out @[DspReal.scala 84:14]
+    inst BBFMultiply_1_1 of BBFMultiply_1 @[DspReal.scala 106:36]
+    BBFMultiply_1_1.out is invalid
+    BBFMultiply_1_1.in2 is invalid
+    BBFMultiply_1_1.in1 is invalid
+    BBFMultiply_1_1.in1 <= stage_outputs_0_4.imaginary.node @[DspReal.scala 81:21]
+    BBFMultiply_1_1.in2 <= twiddle[0].imaginary.node @[DspReal.scala 82:21]
+    wire _T_2598 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_2598 is invalid @[DspReal.scala 83:19]
+    _T_2598.node <= BBFMultiply_1_1.out @[DspReal.scala 84:14]
+    wire _T_2604 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_2604 is invalid @[DspReal.scala 165:19]
+    _T_2604.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    inst BBFSubtract_7_1 of BBFSubtract_7 @[DspReal.scala 102:36]
+    BBFSubtract_7_1.out is invalid
+    BBFSubtract_7_1.in2 is invalid
+    BBFSubtract_7_1.in1 is invalid
+    BBFSubtract_7_1.in1 <= _T_2604.node @[DspReal.scala 81:21]
+    BBFSubtract_7_1.in2 <= _T_2598.node @[DspReal.scala 82:21]
+    wire _T_2611 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_2611 is invalid @[DspReal.scala 83:19]
+    _T_2611.node <= BBFSubtract_7_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_72 of BBFAdd @[DspReal.scala 98:36]
+    BBFAdd_72.out is invalid
+    BBFAdd_72.in2 is invalid
+    BBFAdd_72.in1 is invalid
+    BBFAdd_72.in1 <= _T_2592.node @[DspReal.scala 81:21]
+    BBFAdd_72.in2 <= _T_2611.node @[DspReal.scala 82:21]
+    wire _T_2617 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_2617 is invalid @[DspReal.scala 83:19]
+    _T_2617.node <= BBFAdd_72.out @[DspReal.scala 84:14]
+    inst BBFMultiply_2_1 of BBFMultiply_2 @[DspReal.scala 106:36]
+    BBFMultiply_2_1.out is invalid
+    BBFMultiply_2_1.in2 is invalid
+    BBFMultiply_2_1.in1 is invalid
+    BBFMultiply_2_1.in1 <= stage_outputs_0_4.real.node @[DspReal.scala 81:21]
+    BBFMultiply_2_1.in2 <= twiddle[0].imaginary.node @[DspReal.scala 82:21]
+    wire _T_2623 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_2623 is invalid @[DspReal.scala 83:19]
+    _T_2623.node <= BBFMultiply_2_1.out @[DspReal.scala 84:14]
+    inst BBFMultiply_3_1 of BBFMultiply_3 @[DspReal.scala 106:36]
+    BBFMultiply_3_1.out is invalid
+    BBFMultiply_3_1.in2 is invalid
+    BBFMultiply_3_1.in1 is invalid
+    BBFMultiply_3_1.in1 <= stage_outputs_0_4.imaginary.node @[DspReal.scala 81:21]
+    BBFMultiply_3_1.in2 <= twiddle[0].real.node @[DspReal.scala 82:21]
+    wire _T_2629 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_2629 is invalid @[DspReal.scala 83:19]
+    _T_2629.node <= BBFMultiply_3_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_1_1 of BBFAdd_1 @[DspReal.scala 98:36]
+    BBFAdd_1_1.out is invalid
+    BBFAdd_1_1.in2 is invalid
+    BBFAdd_1_1.in1 is invalid
+    BBFAdd_1_1.in1 <= _T_2623.node @[DspReal.scala 81:21]
+    BBFAdd_1_1.in2 <= _T_2629.node @[DspReal.scala 82:21]
+    wire _T_2635 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_2635 is invalid @[DspReal.scala 83:19]
+    _T_2635.node <= BBFAdd_1_1.out @[DspReal.scala 84:14]
+    wire _T_2651 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_2651 is invalid @[DspComplex.scala 14:22]
+    _T_2651.real.node <= _T_2617.node @[DspComplex.scala 15:17]
+    _T_2651.imaginary.node <= _T_2635.node @[DspComplex.scala 16:22]
+    inst BBFAdd_2_1 of BBFAdd_2 @[DspReal.scala 98:36]
+    BBFAdd_2_1.out is invalid
+    BBFAdd_2_1.in2 is invalid
+    BBFAdd_2_1.in1 is invalid
+    BBFAdd_2_1.in1 <= stage_outputs_0_0.real.node @[DspReal.scala 81:21]
+    BBFAdd_2_1.in2 <= _T_2651.real.node @[DspReal.scala 82:21]
+    wire _T_2655 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_2655 is invalid @[DspReal.scala 83:19]
+    _T_2655.node <= BBFAdd_2_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_3_1 of BBFAdd_3 @[DspReal.scala 98:36]
+    BBFAdd_3_1.out is invalid
+    BBFAdd_3_1.in2 is invalid
+    BBFAdd_3_1.in1 is invalid
+    BBFAdd_3_1.in1 <= stage_outputs_0_0.imaginary.node @[DspReal.scala 81:21]
+    BBFAdd_3_1.in2 <= _T_2651.imaginary.node @[DspReal.scala 82:21]
+    wire _T_2661 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_2661 is invalid @[DspReal.scala 83:19]
+    _T_2661.node <= BBFAdd_3_1.out @[DspReal.scala 84:14]
+    wire _T_2677 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_2677 is invalid @[DspComplex.scala 14:22]
+    _T_2677.real.node <= _T_2655.node @[DspComplex.scala 15:17]
+    _T_2677.imaginary.node <= _T_2661.node @[DspComplex.scala 16:22]
+    wire _T_2681 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_2681 is invalid @[DspReal.scala 165:19]
+    _T_2681.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    inst BBFSubtract_8_1 of BBFSubtract_8 @[DspReal.scala 102:36]
+    BBFSubtract_8_1.out is invalid
+    BBFSubtract_8_1.in2 is invalid
+    BBFSubtract_8_1.in1 is invalid
+    BBFSubtract_8_1.in1 <= _T_2681.node @[DspReal.scala 81:21]
+    BBFSubtract_8_1.in2 <= _T_2651.real.node @[DspReal.scala 82:21]
+    wire _T_2688 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_2688 is invalid @[DspReal.scala 83:19]
+    _T_2688.node <= BBFSubtract_8_1.out @[DspReal.scala 84:14]
+    wire _T_2694 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_2694 is invalid @[DspReal.scala 165:19]
+    _T_2694.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    inst BBFSubtract_9_1 of BBFSubtract_9 @[DspReal.scala 102:36]
+    BBFSubtract_9_1.out is invalid
+    BBFSubtract_9_1.in2 is invalid
+    BBFSubtract_9_1.in1 is invalid
+    BBFSubtract_9_1.in1 <= _T_2694.node @[DspReal.scala 81:21]
+    BBFSubtract_9_1.in2 <= _T_2651.imaginary.node @[DspReal.scala 82:21]
+    wire _T_2701 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_2701 is invalid @[DspReal.scala 83:19]
+    _T_2701.node <= BBFSubtract_9_1.out @[DspReal.scala 84:14]
+    wire _T_2717 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_2717 is invalid @[DspComplex.scala 14:22]
+    _T_2717.real.node <= _T_2688.node @[DspComplex.scala 15:17]
+    _T_2717.imaginary.node <= _T_2701.node @[DspComplex.scala 16:22]
+    inst BBFAdd_4_1 of BBFAdd_4 @[DspReal.scala 98:36]
+    BBFAdd_4_1.out is invalid
+    BBFAdd_4_1.in2 is invalid
+    BBFAdd_4_1.in1 is invalid
+    BBFAdd_4_1.in1 <= stage_outputs_0_0.real.node @[DspReal.scala 81:21]
+    BBFAdd_4_1.in2 <= _T_2717.real.node @[DspReal.scala 82:21]
+    wire _T_2721 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_2721 is invalid @[DspReal.scala 83:19]
+    _T_2721.node <= BBFAdd_4_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_5_1 of BBFAdd_5 @[DspReal.scala 98:36]
+    BBFAdd_5_1.out is invalid
+    BBFAdd_5_1.in2 is invalid
+    BBFAdd_5_1.in1 is invalid
+    BBFAdd_5_1.in1 <= stage_outputs_0_0.imaginary.node @[DspReal.scala 81:21]
+    BBFAdd_5_1.in2 <= _T_2717.imaginary.node @[DspReal.scala 82:21]
+    wire _T_2727 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_2727 is invalid @[DspReal.scala 83:19]
+    _T_2727.node <= BBFAdd_5_1.out @[DspReal.scala 84:14]
+    wire _T_2743 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_2743 is invalid @[DspComplex.scala 14:22]
+    _T_2743.real.node <= _T_2721.node @[DspComplex.scala 15:17]
+    _T_2743.imaginary.node <= _T_2727.node @[DspComplex.scala 16:22]
+    cmem _T_2758 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[1] @[FFTUtilities.scala 169:21]
+    when io.in.valid : @[Counter.scala 59:17]
+      skip @[Counter.scala 59:17]
+    node _T_2761 = and(io.in.valid, UInt<1>("h01")) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_2769 = _T_2758[UInt<1>("h00")], clock
+      _T_2769.imaginary.node <= _T_2677.imaginary.node @[FFTUtilities.scala 172:29]
+      _T_2769.real.node <= _T_2677.real.node @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_2777 = _T_2758[UInt<1>("h00")], clock
+    stage_outputs_1_0.imaginary.node <= _T_2777.imaginary.node @[FFT.scala 75:14]
+    stage_outputs_1_0.real.node <= _T_2777.real.node @[FFT.scala 75:14]
+    cmem _T_2792 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[1] @[FFTUtilities.scala 169:21]
+    when io.in.valid : @[Counter.scala 59:17]
+      skip @[Counter.scala 59:17]
+    node _T_2795 = and(io.in.valid, UInt<1>("h01")) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_2803 = _T_2792[UInt<1>("h00")], clock
+      _T_2803.imaginary.node <= _T_2743.imaginary.node @[FFTUtilities.scala 172:29]
+      _T_2803.real.node <= _T_2743.real.node @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_2811 = _T_2792[UInt<1>("h00")], clock
+    stage_outputs_1_4.imaginary.node <= _T_2811.imaginary.node @[FFT.scala 75:14]
+    stage_outputs_1_4.real.node <= _T_2811.real.node @[FFT.scala 75:14]
+    inst BBFMultiply_4_1 of BBFMultiply_4 @[DspReal.scala 106:36]
+    BBFMultiply_4_1.out is invalid
+    BBFMultiply_4_1.in2 is invalid
+    BBFMultiply_4_1.in1 is invalid
+    BBFMultiply_4_1.in1 <= stage_outputs_0_5.real.node @[DspReal.scala 81:21]
+    BBFMultiply_4_1.in2 <= twiddle[0].real.node @[DspReal.scala 82:21]
+    wire _T_2815 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_2815 is invalid @[DspReal.scala 83:19]
+    _T_2815.node <= BBFMultiply_4_1.out @[DspReal.scala 84:14]
+    inst BBFMultiply_5_1 of BBFMultiply_5 @[DspReal.scala 106:36]
+    BBFMultiply_5_1.out is invalid
+    BBFMultiply_5_1.in2 is invalid
+    BBFMultiply_5_1.in1 is invalid
+    BBFMultiply_5_1.in1 <= stage_outputs_0_5.imaginary.node @[DspReal.scala 81:21]
+    BBFMultiply_5_1.in2 <= twiddle[0].imaginary.node @[DspReal.scala 82:21]
+    wire _T_2821 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_2821 is invalid @[DspReal.scala 83:19]
+    _T_2821.node <= BBFMultiply_5_1.out @[DspReal.scala 84:14]
+    wire _T_2827 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_2827 is invalid @[DspReal.scala 165:19]
+    _T_2827.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    inst BBFSubtract_10_1 of BBFSubtract_10 @[DspReal.scala 102:36]
+    BBFSubtract_10_1.out is invalid
+    BBFSubtract_10_1.in2 is invalid
+    BBFSubtract_10_1.in1 is invalid
+    BBFSubtract_10_1.in1 <= _T_2827.node @[DspReal.scala 81:21]
+    BBFSubtract_10_1.in2 <= _T_2821.node @[DspReal.scala 82:21]
+    wire _T_2834 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_2834 is invalid @[DspReal.scala 83:19]
+    _T_2834.node <= BBFSubtract_10_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_6_1 of BBFAdd_6 @[DspReal.scala 98:36]
+    BBFAdd_6_1.out is invalid
+    BBFAdd_6_1.in2 is invalid
+    BBFAdd_6_1.in1 is invalid
+    BBFAdd_6_1.in1 <= _T_2815.node @[DspReal.scala 81:21]
+    BBFAdd_6_1.in2 <= _T_2834.node @[DspReal.scala 82:21]
+    wire _T_2840 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_2840 is invalid @[DspReal.scala 83:19]
+    _T_2840.node <= BBFAdd_6_1.out @[DspReal.scala 84:14]
+    inst BBFMultiply_6_1 of BBFMultiply_6 @[DspReal.scala 106:36]
+    BBFMultiply_6_1.out is invalid
+    BBFMultiply_6_1.in2 is invalid
+    BBFMultiply_6_1.in1 is invalid
+    BBFMultiply_6_1.in1 <= stage_outputs_0_5.real.node @[DspReal.scala 81:21]
+    BBFMultiply_6_1.in2 <= twiddle[0].imaginary.node @[DspReal.scala 82:21]
+    wire _T_2846 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_2846 is invalid @[DspReal.scala 83:19]
+    _T_2846.node <= BBFMultiply_6_1.out @[DspReal.scala 84:14]
+    inst BBFMultiply_7_1 of BBFMultiply_7 @[DspReal.scala 106:36]
+    BBFMultiply_7_1.out is invalid
+    BBFMultiply_7_1.in2 is invalid
+    BBFMultiply_7_1.in1 is invalid
+    BBFMultiply_7_1.in1 <= stage_outputs_0_5.imaginary.node @[DspReal.scala 81:21]
+    BBFMultiply_7_1.in2 <= twiddle[0].real.node @[DspReal.scala 82:21]
+    wire _T_2852 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_2852 is invalid @[DspReal.scala 83:19]
+    _T_2852.node <= BBFMultiply_7_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_7_1 of BBFAdd_7 @[DspReal.scala 98:36]
+    BBFAdd_7_1.out is invalid
+    BBFAdd_7_1.in2 is invalid
+    BBFAdd_7_1.in1 is invalid
+    BBFAdd_7_1.in1 <= _T_2846.node @[DspReal.scala 81:21]
+    BBFAdd_7_1.in2 <= _T_2852.node @[DspReal.scala 82:21]
+    wire _T_2858 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_2858 is invalid @[DspReal.scala 83:19]
+    _T_2858.node <= BBFAdd_7_1.out @[DspReal.scala 84:14]
+    wire _T_2874 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_2874 is invalid @[DspComplex.scala 14:22]
+    _T_2874.real.node <= _T_2840.node @[DspComplex.scala 15:17]
+    _T_2874.imaginary.node <= _T_2858.node @[DspComplex.scala 16:22]
+    inst BBFAdd_8_1 of BBFAdd_8 @[DspReal.scala 98:36]
+    BBFAdd_8_1.out is invalid
+    BBFAdd_8_1.in2 is invalid
+    BBFAdd_8_1.in1 is invalid
+    BBFAdd_8_1.in1 <= stage_outputs_0_1.real.node @[DspReal.scala 81:21]
+    BBFAdd_8_1.in2 <= _T_2874.real.node @[DspReal.scala 82:21]
+    wire _T_2878 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_2878 is invalid @[DspReal.scala 83:19]
+    _T_2878.node <= BBFAdd_8_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_9_1 of BBFAdd_9 @[DspReal.scala 98:36]
+    BBFAdd_9_1.out is invalid
+    BBFAdd_9_1.in2 is invalid
+    BBFAdd_9_1.in1 is invalid
+    BBFAdd_9_1.in1 <= stage_outputs_0_1.imaginary.node @[DspReal.scala 81:21]
+    BBFAdd_9_1.in2 <= _T_2874.imaginary.node @[DspReal.scala 82:21]
+    wire _T_2884 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_2884 is invalid @[DspReal.scala 83:19]
+    _T_2884.node <= BBFAdd_9_1.out @[DspReal.scala 84:14]
+    wire _T_2900 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_2900 is invalid @[DspComplex.scala 14:22]
+    _T_2900.real.node <= _T_2878.node @[DspComplex.scala 15:17]
+    _T_2900.imaginary.node <= _T_2884.node @[DspComplex.scala 16:22]
+    wire _T_2904 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_2904 is invalid @[DspReal.scala 165:19]
+    _T_2904.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    inst BBFSubtract_11_1 of BBFSubtract_11 @[DspReal.scala 102:36]
+    BBFSubtract_11_1.out is invalid
+    BBFSubtract_11_1.in2 is invalid
+    BBFSubtract_11_1.in1 is invalid
+    BBFSubtract_11_1.in1 <= _T_2904.node @[DspReal.scala 81:21]
+    BBFSubtract_11_1.in2 <= _T_2874.real.node @[DspReal.scala 82:21]
+    wire _T_2911 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_2911 is invalid @[DspReal.scala 83:19]
+    _T_2911.node <= BBFSubtract_11_1.out @[DspReal.scala 84:14]
+    wire _T_2917 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_2917 is invalid @[DspReal.scala 165:19]
+    _T_2917.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    inst BBFSubtract_12_1 of BBFSubtract_12 @[DspReal.scala 102:36]
+    BBFSubtract_12_1.out is invalid
+    BBFSubtract_12_1.in2 is invalid
+    BBFSubtract_12_1.in1 is invalid
+    BBFSubtract_12_1.in1 <= _T_2917.node @[DspReal.scala 81:21]
+    BBFSubtract_12_1.in2 <= _T_2874.imaginary.node @[DspReal.scala 82:21]
+    wire _T_2924 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_2924 is invalid @[DspReal.scala 83:19]
+    _T_2924.node <= BBFSubtract_12_1.out @[DspReal.scala 84:14]
+    wire _T_2940 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_2940 is invalid @[DspComplex.scala 14:22]
+    _T_2940.real.node <= _T_2911.node @[DspComplex.scala 15:17]
+    _T_2940.imaginary.node <= _T_2924.node @[DspComplex.scala 16:22]
+    inst BBFAdd_10_1 of BBFAdd_10 @[DspReal.scala 98:36]
+    BBFAdd_10_1.out is invalid
+    BBFAdd_10_1.in2 is invalid
+    BBFAdd_10_1.in1 is invalid
+    BBFAdd_10_1.in1 <= stage_outputs_0_1.real.node @[DspReal.scala 81:21]
+    BBFAdd_10_1.in2 <= _T_2940.real.node @[DspReal.scala 82:21]
+    wire _T_2944 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_2944 is invalid @[DspReal.scala 83:19]
+    _T_2944.node <= BBFAdd_10_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_11_1 of BBFAdd_11 @[DspReal.scala 98:36]
+    BBFAdd_11_1.out is invalid
+    BBFAdd_11_1.in2 is invalid
+    BBFAdd_11_1.in1 is invalid
+    BBFAdd_11_1.in1 <= stage_outputs_0_1.imaginary.node @[DspReal.scala 81:21]
+    BBFAdd_11_1.in2 <= _T_2940.imaginary.node @[DspReal.scala 82:21]
+    wire _T_2950 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_2950 is invalid @[DspReal.scala 83:19]
+    _T_2950.node <= BBFAdd_11_1.out @[DspReal.scala 84:14]
+    wire _T_2966 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_2966 is invalid @[DspComplex.scala 14:22]
+    _T_2966.real.node <= _T_2944.node @[DspComplex.scala 15:17]
+    _T_2966.imaginary.node <= _T_2950.node @[DspComplex.scala 16:22]
+    cmem _T_2981 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[1] @[FFTUtilities.scala 169:21]
+    when io.in.valid : @[Counter.scala 59:17]
+      skip @[Counter.scala 59:17]
+    node _T_2984 = and(io.in.valid, UInt<1>("h01")) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_2992 = _T_2981[UInt<1>("h00")], clock
+      _T_2992.imaginary.node <= _T_2900.imaginary.node @[FFTUtilities.scala 172:29]
+      _T_2992.real.node <= _T_2900.real.node @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_3000 = _T_2981[UInt<1>("h00")], clock
+    stage_outputs_1_1.imaginary.node <= _T_3000.imaginary.node @[FFT.scala 75:14]
+    stage_outputs_1_1.real.node <= _T_3000.real.node @[FFT.scala 75:14]
+    cmem _T_3015 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[1] @[FFTUtilities.scala 169:21]
+    when io.in.valid : @[Counter.scala 59:17]
+      skip @[Counter.scala 59:17]
+    node _T_3018 = and(io.in.valid, UInt<1>("h01")) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_3026 = _T_3015[UInt<1>("h00")], clock
+      _T_3026.imaginary.node <= _T_2966.imaginary.node @[FFTUtilities.scala 172:29]
+      _T_3026.real.node <= _T_2966.real.node @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_3034 = _T_3015[UInt<1>("h00")], clock
+    stage_outputs_1_5.imaginary.node <= _T_3034.imaginary.node @[FFT.scala 75:14]
+    stage_outputs_1_5.real.node <= _T_3034.real.node @[FFT.scala 75:14]
+    inst BBFMultiply_8_1 of BBFMultiply_8 @[DspReal.scala 106:36]
+    BBFMultiply_8_1.out is invalid
+    BBFMultiply_8_1.in2 is invalid
+    BBFMultiply_8_1.in1 is invalid
+    BBFMultiply_8_1.in1 <= stage_outputs_0_6.real.node @[DspReal.scala 81:21]
+    BBFMultiply_8_1.in2 <= twiddle[0].real.node @[DspReal.scala 82:21]
+    wire _T_3038 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3038 is invalid @[DspReal.scala 83:19]
+    _T_3038.node <= BBFMultiply_8_1.out @[DspReal.scala 84:14]
+    inst BBFMultiply_9_1 of BBFMultiply_9 @[DspReal.scala 106:36]
+    BBFMultiply_9_1.out is invalid
+    BBFMultiply_9_1.in2 is invalid
+    BBFMultiply_9_1.in1 is invalid
+    BBFMultiply_9_1.in1 <= stage_outputs_0_6.imaginary.node @[DspReal.scala 81:21]
+    BBFMultiply_9_1.in2 <= twiddle[0].imaginary.node @[DspReal.scala 82:21]
+    wire _T_3044 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3044 is invalid @[DspReal.scala 83:19]
+    _T_3044.node <= BBFMultiply_9_1.out @[DspReal.scala 84:14]
+    wire _T_3050 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_3050 is invalid @[DspReal.scala 165:19]
+    _T_3050.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    inst BBFSubtract_13_1 of BBFSubtract_13 @[DspReal.scala 102:36]
+    BBFSubtract_13_1.out is invalid
+    BBFSubtract_13_1.in2 is invalid
+    BBFSubtract_13_1.in1 is invalid
+    BBFSubtract_13_1.in1 <= _T_3050.node @[DspReal.scala 81:21]
+    BBFSubtract_13_1.in2 <= _T_3044.node @[DspReal.scala 82:21]
+    wire _T_3057 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3057 is invalid @[DspReal.scala 83:19]
+    _T_3057.node <= BBFSubtract_13_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_12_1 of BBFAdd_12 @[DspReal.scala 98:36]
+    BBFAdd_12_1.out is invalid
+    BBFAdd_12_1.in2 is invalid
+    BBFAdd_12_1.in1 is invalid
+    BBFAdd_12_1.in1 <= _T_3038.node @[DspReal.scala 81:21]
+    BBFAdd_12_1.in2 <= _T_3057.node @[DspReal.scala 82:21]
+    wire _T_3063 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3063 is invalid @[DspReal.scala 83:19]
+    _T_3063.node <= BBFAdd_12_1.out @[DspReal.scala 84:14]
+    inst BBFMultiply_10_1 of BBFMultiply_10 @[DspReal.scala 106:36]
+    BBFMultiply_10_1.out is invalid
+    BBFMultiply_10_1.in2 is invalid
+    BBFMultiply_10_1.in1 is invalid
+    BBFMultiply_10_1.in1 <= stage_outputs_0_6.real.node @[DspReal.scala 81:21]
+    BBFMultiply_10_1.in2 <= twiddle[0].imaginary.node @[DspReal.scala 82:21]
+    wire _T_3069 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3069 is invalid @[DspReal.scala 83:19]
+    _T_3069.node <= BBFMultiply_10_1.out @[DspReal.scala 84:14]
+    inst BBFMultiply_11_1 of BBFMultiply_11 @[DspReal.scala 106:36]
+    BBFMultiply_11_1.out is invalid
+    BBFMultiply_11_1.in2 is invalid
+    BBFMultiply_11_1.in1 is invalid
+    BBFMultiply_11_1.in1 <= stage_outputs_0_6.imaginary.node @[DspReal.scala 81:21]
+    BBFMultiply_11_1.in2 <= twiddle[0].real.node @[DspReal.scala 82:21]
+    wire _T_3075 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3075 is invalid @[DspReal.scala 83:19]
+    _T_3075.node <= BBFMultiply_11_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_13_1 of BBFAdd_13 @[DspReal.scala 98:36]
+    BBFAdd_13_1.out is invalid
+    BBFAdd_13_1.in2 is invalid
+    BBFAdd_13_1.in1 is invalid
+    BBFAdd_13_1.in1 <= _T_3069.node @[DspReal.scala 81:21]
+    BBFAdd_13_1.in2 <= _T_3075.node @[DspReal.scala 82:21]
+    wire _T_3081 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3081 is invalid @[DspReal.scala 83:19]
+    _T_3081.node <= BBFAdd_13_1.out @[DspReal.scala 84:14]
+    wire _T_3097 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_3097 is invalid @[DspComplex.scala 14:22]
+    _T_3097.real.node <= _T_3063.node @[DspComplex.scala 15:17]
+    _T_3097.imaginary.node <= _T_3081.node @[DspComplex.scala 16:22]
+    inst BBFAdd_14_1 of BBFAdd_14 @[DspReal.scala 98:36]
+    BBFAdd_14_1.out is invalid
+    BBFAdd_14_1.in2 is invalid
+    BBFAdd_14_1.in1 is invalid
+    BBFAdd_14_1.in1 <= stage_outputs_0_2.real.node @[DspReal.scala 81:21]
+    BBFAdd_14_1.in2 <= _T_3097.real.node @[DspReal.scala 82:21]
+    wire _T_3101 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3101 is invalid @[DspReal.scala 83:19]
+    _T_3101.node <= BBFAdd_14_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_15_1 of BBFAdd_15 @[DspReal.scala 98:36]
+    BBFAdd_15_1.out is invalid
+    BBFAdd_15_1.in2 is invalid
+    BBFAdd_15_1.in1 is invalid
+    BBFAdd_15_1.in1 <= stage_outputs_0_2.imaginary.node @[DspReal.scala 81:21]
+    BBFAdd_15_1.in2 <= _T_3097.imaginary.node @[DspReal.scala 82:21]
+    wire _T_3107 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3107 is invalid @[DspReal.scala 83:19]
+    _T_3107.node <= BBFAdd_15_1.out @[DspReal.scala 84:14]
+    wire _T_3123 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_3123 is invalid @[DspComplex.scala 14:22]
+    _T_3123.real.node <= _T_3101.node @[DspComplex.scala 15:17]
+    _T_3123.imaginary.node <= _T_3107.node @[DspComplex.scala 16:22]
+    wire _T_3127 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_3127 is invalid @[DspReal.scala 165:19]
+    _T_3127.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    inst BBFSubtract_14_1 of BBFSubtract_14 @[DspReal.scala 102:36]
+    BBFSubtract_14_1.out is invalid
+    BBFSubtract_14_1.in2 is invalid
+    BBFSubtract_14_1.in1 is invalid
+    BBFSubtract_14_1.in1 <= _T_3127.node @[DspReal.scala 81:21]
+    BBFSubtract_14_1.in2 <= _T_3097.real.node @[DspReal.scala 82:21]
+    wire _T_3134 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3134 is invalid @[DspReal.scala 83:19]
+    _T_3134.node <= BBFSubtract_14_1.out @[DspReal.scala 84:14]
+    wire _T_3140 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_3140 is invalid @[DspReal.scala 165:19]
+    _T_3140.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    inst BBFSubtract_15_1 of BBFSubtract_15 @[DspReal.scala 102:36]
+    BBFSubtract_15_1.out is invalid
+    BBFSubtract_15_1.in2 is invalid
+    BBFSubtract_15_1.in1 is invalid
+    BBFSubtract_15_1.in1 <= _T_3140.node @[DspReal.scala 81:21]
+    BBFSubtract_15_1.in2 <= _T_3097.imaginary.node @[DspReal.scala 82:21]
+    wire _T_3147 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3147 is invalid @[DspReal.scala 83:19]
+    _T_3147.node <= BBFSubtract_15_1.out @[DspReal.scala 84:14]
+    wire _T_3163 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_3163 is invalid @[DspComplex.scala 14:22]
+    _T_3163.real.node <= _T_3134.node @[DspComplex.scala 15:17]
+    _T_3163.imaginary.node <= _T_3147.node @[DspComplex.scala 16:22]
+    inst BBFAdd_16_1 of BBFAdd_16 @[DspReal.scala 98:36]
+    BBFAdd_16_1.out is invalid
+    BBFAdd_16_1.in2 is invalid
+    BBFAdd_16_1.in1 is invalid
+    BBFAdd_16_1.in1 <= stage_outputs_0_2.real.node @[DspReal.scala 81:21]
+    BBFAdd_16_1.in2 <= _T_3163.real.node @[DspReal.scala 82:21]
+    wire _T_3167 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3167 is invalid @[DspReal.scala 83:19]
+    _T_3167.node <= BBFAdd_16_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_17_1 of BBFAdd_17 @[DspReal.scala 98:36]
+    BBFAdd_17_1.out is invalid
+    BBFAdd_17_1.in2 is invalid
+    BBFAdd_17_1.in1 is invalid
+    BBFAdd_17_1.in1 <= stage_outputs_0_2.imaginary.node @[DspReal.scala 81:21]
+    BBFAdd_17_1.in2 <= _T_3163.imaginary.node @[DspReal.scala 82:21]
+    wire _T_3173 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3173 is invalid @[DspReal.scala 83:19]
+    _T_3173.node <= BBFAdd_17_1.out @[DspReal.scala 84:14]
+    wire _T_3189 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_3189 is invalid @[DspComplex.scala 14:22]
+    _T_3189.real.node <= _T_3167.node @[DspComplex.scala 15:17]
+    _T_3189.imaginary.node <= _T_3173.node @[DspComplex.scala 16:22]
+    cmem _T_3204 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[1] @[FFTUtilities.scala 169:21]
+    when io.in.valid : @[Counter.scala 59:17]
+      skip @[Counter.scala 59:17]
+    node _T_3207 = and(io.in.valid, UInt<1>("h01")) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_3215 = _T_3204[UInt<1>("h00")], clock
+      _T_3215.imaginary.node <= _T_3123.imaginary.node @[FFTUtilities.scala 172:29]
+      _T_3215.real.node <= _T_3123.real.node @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_3223 = _T_3204[UInt<1>("h00")], clock
+    stage_outputs_1_2.imaginary.node <= _T_3223.imaginary.node @[FFT.scala 75:14]
+    stage_outputs_1_2.real.node <= _T_3223.real.node @[FFT.scala 75:14]
+    cmem _T_3238 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[1] @[FFTUtilities.scala 169:21]
+    when io.in.valid : @[Counter.scala 59:17]
+      skip @[Counter.scala 59:17]
+    node _T_3241 = and(io.in.valid, UInt<1>("h01")) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_3249 = _T_3238[UInt<1>("h00")], clock
+      _T_3249.imaginary.node <= _T_3189.imaginary.node @[FFTUtilities.scala 172:29]
+      _T_3249.real.node <= _T_3189.real.node @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_3257 = _T_3238[UInt<1>("h00")], clock
+    stage_outputs_1_6.imaginary.node <= _T_3257.imaginary.node @[FFT.scala 75:14]
+    stage_outputs_1_6.real.node <= _T_3257.real.node @[FFT.scala 75:14]
+    inst BBFMultiply_12_1 of BBFMultiply_12 @[DspReal.scala 106:36]
+    BBFMultiply_12_1.out is invalid
+    BBFMultiply_12_1.in2 is invalid
+    BBFMultiply_12_1.in1 is invalid
+    BBFMultiply_12_1.in1 <= stage_outputs_0_7.real.node @[DspReal.scala 81:21]
+    BBFMultiply_12_1.in2 <= twiddle[0].real.node @[DspReal.scala 82:21]
+    wire _T_3261 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3261 is invalid @[DspReal.scala 83:19]
+    _T_3261.node <= BBFMultiply_12_1.out @[DspReal.scala 84:14]
+    inst BBFMultiply_13_1 of BBFMultiply_13 @[DspReal.scala 106:36]
+    BBFMultiply_13_1.out is invalid
+    BBFMultiply_13_1.in2 is invalid
+    BBFMultiply_13_1.in1 is invalid
+    BBFMultiply_13_1.in1 <= stage_outputs_0_7.imaginary.node @[DspReal.scala 81:21]
+    BBFMultiply_13_1.in2 <= twiddle[0].imaginary.node @[DspReal.scala 82:21]
+    wire _T_3267 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3267 is invalid @[DspReal.scala 83:19]
+    _T_3267.node <= BBFMultiply_13_1.out @[DspReal.scala 84:14]
+    wire _T_3273 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_3273 is invalid @[DspReal.scala 165:19]
+    _T_3273.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    inst BBFSubtract_16_1 of BBFSubtract_16 @[DspReal.scala 102:36]
+    BBFSubtract_16_1.out is invalid
+    BBFSubtract_16_1.in2 is invalid
+    BBFSubtract_16_1.in1 is invalid
+    BBFSubtract_16_1.in1 <= _T_3273.node @[DspReal.scala 81:21]
+    BBFSubtract_16_1.in2 <= _T_3267.node @[DspReal.scala 82:21]
+    wire _T_3280 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3280 is invalid @[DspReal.scala 83:19]
+    _T_3280.node <= BBFSubtract_16_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_18_1 of BBFAdd_18 @[DspReal.scala 98:36]
+    BBFAdd_18_1.out is invalid
+    BBFAdd_18_1.in2 is invalid
+    BBFAdd_18_1.in1 is invalid
+    BBFAdd_18_1.in1 <= _T_3261.node @[DspReal.scala 81:21]
+    BBFAdd_18_1.in2 <= _T_3280.node @[DspReal.scala 82:21]
+    wire _T_3286 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3286 is invalid @[DspReal.scala 83:19]
+    _T_3286.node <= BBFAdd_18_1.out @[DspReal.scala 84:14]
+    inst BBFMultiply_14_1 of BBFMultiply_14 @[DspReal.scala 106:36]
+    BBFMultiply_14_1.out is invalid
+    BBFMultiply_14_1.in2 is invalid
+    BBFMultiply_14_1.in1 is invalid
+    BBFMultiply_14_1.in1 <= stage_outputs_0_7.real.node @[DspReal.scala 81:21]
+    BBFMultiply_14_1.in2 <= twiddle[0].imaginary.node @[DspReal.scala 82:21]
+    wire _T_3292 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3292 is invalid @[DspReal.scala 83:19]
+    _T_3292.node <= BBFMultiply_14_1.out @[DspReal.scala 84:14]
+    inst BBFMultiply_15_1 of BBFMultiply_15 @[DspReal.scala 106:36]
+    BBFMultiply_15_1.out is invalid
+    BBFMultiply_15_1.in2 is invalid
+    BBFMultiply_15_1.in1 is invalid
+    BBFMultiply_15_1.in1 <= stage_outputs_0_7.imaginary.node @[DspReal.scala 81:21]
+    BBFMultiply_15_1.in2 <= twiddle[0].real.node @[DspReal.scala 82:21]
+    wire _T_3298 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3298 is invalid @[DspReal.scala 83:19]
+    _T_3298.node <= BBFMultiply_15_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_19_1 of BBFAdd_19 @[DspReal.scala 98:36]
+    BBFAdd_19_1.out is invalid
+    BBFAdd_19_1.in2 is invalid
+    BBFAdd_19_1.in1 is invalid
+    BBFAdd_19_1.in1 <= _T_3292.node @[DspReal.scala 81:21]
+    BBFAdd_19_1.in2 <= _T_3298.node @[DspReal.scala 82:21]
+    wire _T_3304 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3304 is invalid @[DspReal.scala 83:19]
+    _T_3304.node <= BBFAdd_19_1.out @[DspReal.scala 84:14]
+    wire _T_3320 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_3320 is invalid @[DspComplex.scala 14:22]
+    _T_3320.real.node <= _T_3286.node @[DspComplex.scala 15:17]
+    _T_3320.imaginary.node <= _T_3304.node @[DspComplex.scala 16:22]
+    inst BBFAdd_20_1 of BBFAdd_20 @[DspReal.scala 98:36]
+    BBFAdd_20_1.out is invalid
+    BBFAdd_20_1.in2 is invalid
+    BBFAdd_20_1.in1 is invalid
+    BBFAdd_20_1.in1 <= stage_outputs_0_3.real.node @[DspReal.scala 81:21]
+    BBFAdd_20_1.in2 <= _T_3320.real.node @[DspReal.scala 82:21]
+    wire _T_3324 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3324 is invalid @[DspReal.scala 83:19]
+    _T_3324.node <= BBFAdd_20_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_21_1 of BBFAdd_21 @[DspReal.scala 98:36]
+    BBFAdd_21_1.out is invalid
+    BBFAdd_21_1.in2 is invalid
+    BBFAdd_21_1.in1 is invalid
+    BBFAdd_21_1.in1 <= stage_outputs_0_3.imaginary.node @[DspReal.scala 81:21]
+    BBFAdd_21_1.in2 <= _T_3320.imaginary.node @[DspReal.scala 82:21]
+    wire _T_3330 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3330 is invalid @[DspReal.scala 83:19]
+    _T_3330.node <= BBFAdd_21_1.out @[DspReal.scala 84:14]
+    wire _T_3346 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_3346 is invalid @[DspComplex.scala 14:22]
+    _T_3346.real.node <= _T_3324.node @[DspComplex.scala 15:17]
+    _T_3346.imaginary.node <= _T_3330.node @[DspComplex.scala 16:22]
+    wire _T_3350 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_3350 is invalid @[DspReal.scala 165:19]
+    _T_3350.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    inst BBFSubtract_17_1 of BBFSubtract_17 @[DspReal.scala 102:36]
+    BBFSubtract_17_1.out is invalid
+    BBFSubtract_17_1.in2 is invalid
+    BBFSubtract_17_1.in1 is invalid
+    BBFSubtract_17_1.in1 <= _T_3350.node @[DspReal.scala 81:21]
+    BBFSubtract_17_1.in2 <= _T_3320.real.node @[DspReal.scala 82:21]
+    wire _T_3357 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3357 is invalid @[DspReal.scala 83:19]
+    _T_3357.node <= BBFSubtract_17_1.out @[DspReal.scala 84:14]
+    wire _T_3363 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_3363 is invalid @[DspReal.scala 165:19]
+    _T_3363.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    inst BBFSubtract_18_1 of BBFSubtract_18 @[DspReal.scala 102:36]
+    BBFSubtract_18_1.out is invalid
+    BBFSubtract_18_1.in2 is invalid
+    BBFSubtract_18_1.in1 is invalid
+    BBFSubtract_18_1.in1 <= _T_3363.node @[DspReal.scala 81:21]
+    BBFSubtract_18_1.in2 <= _T_3320.imaginary.node @[DspReal.scala 82:21]
+    wire _T_3370 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3370 is invalid @[DspReal.scala 83:19]
+    _T_3370.node <= BBFSubtract_18_1.out @[DspReal.scala 84:14]
+    wire _T_3386 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_3386 is invalid @[DspComplex.scala 14:22]
+    _T_3386.real.node <= _T_3357.node @[DspComplex.scala 15:17]
+    _T_3386.imaginary.node <= _T_3370.node @[DspComplex.scala 16:22]
+    inst BBFAdd_22_1 of BBFAdd_22 @[DspReal.scala 98:36]
+    BBFAdd_22_1.out is invalid
+    BBFAdd_22_1.in2 is invalid
+    BBFAdd_22_1.in1 is invalid
+    BBFAdd_22_1.in1 <= stage_outputs_0_3.real.node @[DspReal.scala 81:21]
+    BBFAdd_22_1.in2 <= _T_3386.real.node @[DspReal.scala 82:21]
+    wire _T_3390 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3390 is invalid @[DspReal.scala 83:19]
+    _T_3390.node <= BBFAdd_22_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_23_1 of BBFAdd_23 @[DspReal.scala 98:36]
+    BBFAdd_23_1.out is invalid
+    BBFAdd_23_1.in2 is invalid
+    BBFAdd_23_1.in1 is invalid
+    BBFAdd_23_1.in1 <= stage_outputs_0_3.imaginary.node @[DspReal.scala 81:21]
+    BBFAdd_23_1.in2 <= _T_3386.imaginary.node @[DspReal.scala 82:21]
+    wire _T_3396 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3396 is invalid @[DspReal.scala 83:19]
+    _T_3396.node <= BBFAdd_23_1.out @[DspReal.scala 84:14]
+    wire _T_3412 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_3412 is invalid @[DspComplex.scala 14:22]
+    _T_3412.real.node <= _T_3390.node @[DspComplex.scala 15:17]
+    _T_3412.imaginary.node <= _T_3396.node @[DspComplex.scala 16:22]
+    cmem _T_3427 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[1] @[FFTUtilities.scala 169:21]
+    when io.in.valid : @[Counter.scala 59:17]
+      skip @[Counter.scala 59:17]
+    node _T_3430 = and(io.in.valid, UInt<1>("h01")) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_3438 = _T_3427[UInt<1>("h00")], clock
+      _T_3438.imaginary.node <= _T_3346.imaginary.node @[FFTUtilities.scala 172:29]
+      _T_3438.real.node <= _T_3346.real.node @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_3446 = _T_3427[UInt<1>("h00")], clock
+    stage_outputs_1_3.imaginary.node <= _T_3446.imaginary.node @[FFT.scala 75:14]
+    stage_outputs_1_3.real.node <= _T_3446.real.node @[FFT.scala 75:14]
+    cmem _T_3461 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[1] @[FFTUtilities.scala 169:21]
+    when io.in.valid : @[Counter.scala 59:17]
+      skip @[Counter.scala 59:17]
+    node _T_3464 = and(io.in.valid, UInt<1>("h01")) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_3472 = _T_3461[UInt<1>("h00")], clock
+      _T_3472.imaginary.node <= _T_3412.imaginary.node @[FFTUtilities.scala 172:29]
+      _T_3472.real.node <= _T_3412.real.node @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_3480 = _T_3461[UInt<1>("h00")], clock
+    stage_outputs_1_7.imaginary.node <= _T_3480.imaginary.node @[FFT.scala 75:14]
+    stage_outputs_1_7.real.node <= _T_3480.real.node @[FFT.scala 75:14]
+    cmem _T_3495 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[1] @[FFTUtilities.scala 169:21]
+    when io.in.valid : @[Counter.scala 59:17]
+      skip @[Counter.scala 59:17]
+    node _T_3498 = and(io.in.valid, UInt<1>("h01")) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_3506 = _T_3495[UInt<1>("h00")], clock
+      _T_3506.imaginary.node <= twiddle[1].imaginary.node @[FFTUtilities.scala 172:29]
+      _T_3506.real.node <= twiddle[1].real.node @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_3514 = _T_3495[UInt<1>("h00")], clock
+    inst BBFMultiply_16_1 of BBFMultiply_16 @[DspReal.scala 106:36]
+    BBFMultiply_16_1.out is invalid
+    BBFMultiply_16_1.in2 is invalid
+    BBFMultiply_16_1.in1 is invalid
+    BBFMultiply_16_1.in1 <= stage_outputs_1_2.real.node @[DspReal.scala 81:21]
+    BBFMultiply_16_1.in2 <= _T_3514.real.node @[DspReal.scala 82:21]
+    wire _T_3518 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3518 is invalid @[DspReal.scala 83:19]
+    _T_3518.node <= BBFMultiply_16_1.out @[DspReal.scala 84:14]
+    inst BBFMultiply_17_1 of BBFMultiply_17 @[DspReal.scala 106:36]
+    BBFMultiply_17_1.out is invalid
+    BBFMultiply_17_1.in2 is invalid
+    BBFMultiply_17_1.in1 is invalid
+    BBFMultiply_17_1.in1 <= stage_outputs_1_2.imaginary.node @[DspReal.scala 81:21]
+    BBFMultiply_17_1.in2 <= _T_3514.imaginary.node @[DspReal.scala 82:21]
+    wire _T_3524 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3524 is invalid @[DspReal.scala 83:19]
+    _T_3524.node <= BBFMultiply_17_1.out @[DspReal.scala 84:14]
+    wire _T_3530 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_3530 is invalid @[DspReal.scala 165:19]
+    _T_3530.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    inst BBFSubtract_19_1 of BBFSubtract_19 @[DspReal.scala 102:36]
+    BBFSubtract_19_1.out is invalid
+    BBFSubtract_19_1.in2 is invalid
+    BBFSubtract_19_1.in1 is invalid
+    BBFSubtract_19_1.in1 <= _T_3530.node @[DspReal.scala 81:21]
+    BBFSubtract_19_1.in2 <= _T_3524.node @[DspReal.scala 82:21]
+    wire _T_3537 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3537 is invalid @[DspReal.scala 83:19]
+    _T_3537.node <= BBFSubtract_19_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_24_1 of BBFAdd_24 @[DspReal.scala 98:36]
+    BBFAdd_24_1.out is invalid
+    BBFAdd_24_1.in2 is invalid
+    BBFAdd_24_1.in1 is invalid
+    BBFAdd_24_1.in1 <= _T_3518.node @[DspReal.scala 81:21]
+    BBFAdd_24_1.in2 <= _T_3537.node @[DspReal.scala 82:21]
+    wire _T_3543 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3543 is invalid @[DspReal.scala 83:19]
+    _T_3543.node <= BBFAdd_24_1.out @[DspReal.scala 84:14]
+    inst BBFMultiply_18_1 of BBFMultiply_18 @[DspReal.scala 106:36]
+    BBFMultiply_18_1.out is invalid
+    BBFMultiply_18_1.in2 is invalid
+    BBFMultiply_18_1.in1 is invalid
+    BBFMultiply_18_1.in1 <= stage_outputs_1_2.real.node @[DspReal.scala 81:21]
+    BBFMultiply_18_1.in2 <= _T_3514.imaginary.node @[DspReal.scala 82:21]
+    wire _T_3549 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3549 is invalid @[DspReal.scala 83:19]
+    _T_3549.node <= BBFMultiply_18_1.out @[DspReal.scala 84:14]
+    inst BBFMultiply_19_1 of BBFMultiply_19 @[DspReal.scala 106:36]
+    BBFMultiply_19_1.out is invalid
+    BBFMultiply_19_1.in2 is invalid
+    BBFMultiply_19_1.in1 is invalid
+    BBFMultiply_19_1.in1 <= stage_outputs_1_2.imaginary.node @[DspReal.scala 81:21]
+    BBFMultiply_19_1.in2 <= _T_3514.real.node @[DspReal.scala 82:21]
+    wire _T_3555 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3555 is invalid @[DspReal.scala 83:19]
+    _T_3555.node <= BBFMultiply_19_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_25_1 of BBFAdd_25 @[DspReal.scala 98:36]
+    BBFAdd_25_1.out is invalid
+    BBFAdd_25_1.in2 is invalid
+    BBFAdd_25_1.in1 is invalid
+    BBFAdd_25_1.in1 <= _T_3549.node @[DspReal.scala 81:21]
+    BBFAdd_25_1.in2 <= _T_3555.node @[DspReal.scala 82:21]
+    wire _T_3561 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3561 is invalid @[DspReal.scala 83:19]
+    _T_3561.node <= BBFAdd_25_1.out @[DspReal.scala 84:14]
+    wire _T_3577 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_3577 is invalid @[DspComplex.scala 14:22]
+    _T_3577.real.node <= _T_3543.node @[DspComplex.scala 15:17]
+    _T_3577.imaginary.node <= _T_3561.node @[DspComplex.scala 16:22]
+    inst BBFAdd_26_1 of BBFAdd_26 @[DspReal.scala 98:36]
+    BBFAdd_26_1.out is invalid
+    BBFAdd_26_1.in2 is invalid
+    BBFAdd_26_1.in1 is invalid
+    BBFAdd_26_1.in1 <= stage_outputs_1_0.real.node @[DspReal.scala 81:21]
+    BBFAdd_26_1.in2 <= _T_3577.real.node @[DspReal.scala 82:21]
+    wire _T_3581 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3581 is invalid @[DspReal.scala 83:19]
+    _T_3581.node <= BBFAdd_26_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_27_1 of BBFAdd_27 @[DspReal.scala 98:36]
+    BBFAdd_27_1.out is invalid
+    BBFAdd_27_1.in2 is invalid
+    BBFAdd_27_1.in1 is invalid
+    BBFAdd_27_1.in1 <= stage_outputs_1_0.imaginary.node @[DspReal.scala 81:21]
+    BBFAdd_27_1.in2 <= _T_3577.imaginary.node @[DspReal.scala 82:21]
+    wire _T_3587 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3587 is invalid @[DspReal.scala 83:19]
+    _T_3587.node <= BBFAdd_27_1.out @[DspReal.scala 84:14]
+    wire _T_3603 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_3603 is invalid @[DspComplex.scala 14:22]
+    _T_3603.real.node <= _T_3581.node @[DspComplex.scala 15:17]
+    _T_3603.imaginary.node <= _T_3587.node @[DspComplex.scala 16:22]
+    wire _T_3607 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_3607 is invalid @[DspReal.scala 165:19]
+    _T_3607.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    inst BBFSubtract_20_1 of BBFSubtract_20 @[DspReal.scala 102:36]
+    BBFSubtract_20_1.out is invalid
+    BBFSubtract_20_1.in2 is invalid
+    BBFSubtract_20_1.in1 is invalid
+    BBFSubtract_20_1.in1 <= _T_3607.node @[DspReal.scala 81:21]
+    BBFSubtract_20_1.in2 <= _T_3577.real.node @[DspReal.scala 82:21]
+    wire _T_3614 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3614 is invalid @[DspReal.scala 83:19]
+    _T_3614.node <= BBFSubtract_20_1.out @[DspReal.scala 84:14]
+    wire _T_3620 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_3620 is invalid @[DspReal.scala 165:19]
+    _T_3620.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    inst BBFSubtract_21_1 of BBFSubtract_21 @[DspReal.scala 102:36]
+    BBFSubtract_21_1.out is invalid
+    BBFSubtract_21_1.in2 is invalid
+    BBFSubtract_21_1.in1 is invalid
+    BBFSubtract_21_1.in1 <= _T_3620.node @[DspReal.scala 81:21]
+    BBFSubtract_21_1.in2 <= _T_3577.imaginary.node @[DspReal.scala 82:21]
+    wire _T_3627 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3627 is invalid @[DspReal.scala 83:19]
+    _T_3627.node <= BBFSubtract_21_1.out @[DspReal.scala 84:14]
+    wire _T_3643 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_3643 is invalid @[DspComplex.scala 14:22]
+    _T_3643.real.node <= _T_3614.node @[DspComplex.scala 15:17]
+    _T_3643.imaginary.node <= _T_3627.node @[DspComplex.scala 16:22]
+    inst BBFAdd_28_1 of BBFAdd_28 @[DspReal.scala 98:36]
+    BBFAdd_28_1.out is invalid
+    BBFAdd_28_1.in2 is invalid
+    BBFAdd_28_1.in1 is invalid
+    BBFAdd_28_1.in1 <= stage_outputs_1_0.real.node @[DspReal.scala 81:21]
+    BBFAdd_28_1.in2 <= _T_3643.real.node @[DspReal.scala 82:21]
+    wire _T_3647 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3647 is invalid @[DspReal.scala 83:19]
+    _T_3647.node <= BBFAdd_28_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_29_1 of BBFAdd_29 @[DspReal.scala 98:36]
+    BBFAdd_29_1.out is invalid
+    BBFAdd_29_1.in2 is invalid
+    BBFAdd_29_1.in1 is invalid
+    BBFAdd_29_1.in1 <= stage_outputs_1_0.imaginary.node @[DspReal.scala 81:21]
+    BBFAdd_29_1.in2 <= _T_3643.imaginary.node @[DspReal.scala 82:21]
+    wire _T_3653 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3653 is invalid @[DspReal.scala 83:19]
+    _T_3653.node <= BBFAdd_29_1.out @[DspReal.scala 84:14]
+    wire _T_3669 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_3669 is invalid @[DspComplex.scala 14:22]
+    _T_3669.real.node <= _T_3647.node @[DspComplex.scala 15:17]
+    _T_3669.imaginary.node <= _T_3653.node @[DspComplex.scala 16:22]
+    cmem _T_3684 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[1] @[FFTUtilities.scala 169:21]
+    when io.in.valid : @[Counter.scala 59:17]
+      skip @[Counter.scala 59:17]
+    node _T_3687 = and(io.in.valid, UInt<1>("h01")) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_3695 = _T_3684[UInt<1>("h00")], clock
+      _T_3695.imaginary.node <= _T_3603.imaginary.node @[FFTUtilities.scala 172:29]
+      _T_3695.real.node <= _T_3603.real.node @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_3703 = _T_3684[UInt<1>("h00")], clock
+    stage_outputs_2_0.imaginary.node <= _T_3703.imaginary.node @[FFT.scala 75:14]
+    stage_outputs_2_0.real.node <= _T_3703.real.node @[FFT.scala 75:14]
+    cmem _T_3718 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[1] @[FFTUtilities.scala 169:21]
+    when io.in.valid : @[Counter.scala 59:17]
+      skip @[Counter.scala 59:17]
+    node _T_3721 = and(io.in.valid, UInt<1>("h01")) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_3729 = _T_3718[UInt<1>("h00")], clock
+      _T_3729.imaginary.node <= _T_3669.imaginary.node @[FFTUtilities.scala 172:29]
+      _T_3729.real.node <= _T_3669.real.node @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_3737 = _T_3718[UInt<1>("h00")], clock
+    stage_outputs_2_2.imaginary.node <= _T_3737.imaginary.node @[FFT.scala 75:14]
+    stage_outputs_2_2.real.node <= _T_3737.real.node @[FFT.scala 75:14]
+    cmem _T_3752 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[1] @[FFTUtilities.scala 169:21]
+    when io.in.valid : @[Counter.scala 59:17]
+      skip @[Counter.scala 59:17]
+    node _T_3755 = and(io.in.valid, UInt<1>("h01")) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_3763 = _T_3752[UInt<1>("h00")], clock
+      _T_3763.imaginary.node <= twiddle[1].imaginary.node @[FFTUtilities.scala 172:29]
+      _T_3763.real.node <= twiddle[1].real.node @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_3771 = _T_3752[UInt<1>("h00")], clock
+    inst BBFMultiply_20_1 of BBFMultiply_20 @[DspReal.scala 106:36]
+    BBFMultiply_20_1.out is invalid
+    BBFMultiply_20_1.in2 is invalid
+    BBFMultiply_20_1.in1 is invalid
+    BBFMultiply_20_1.in1 <= stage_outputs_1_3.real.node @[DspReal.scala 81:21]
+    BBFMultiply_20_1.in2 <= _T_3771.real.node @[DspReal.scala 82:21]
+    wire _T_3775 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3775 is invalid @[DspReal.scala 83:19]
+    _T_3775.node <= BBFMultiply_20_1.out @[DspReal.scala 84:14]
+    inst BBFMultiply_21_1 of BBFMultiply_21 @[DspReal.scala 106:36]
+    BBFMultiply_21_1.out is invalid
+    BBFMultiply_21_1.in2 is invalid
+    BBFMultiply_21_1.in1 is invalid
+    BBFMultiply_21_1.in1 <= stage_outputs_1_3.imaginary.node @[DspReal.scala 81:21]
+    BBFMultiply_21_1.in2 <= _T_3771.imaginary.node @[DspReal.scala 82:21]
+    wire _T_3781 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3781 is invalid @[DspReal.scala 83:19]
+    _T_3781.node <= BBFMultiply_21_1.out @[DspReal.scala 84:14]
+    wire _T_3787 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_3787 is invalid @[DspReal.scala 165:19]
+    _T_3787.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    inst BBFSubtract_22_1 of BBFSubtract_22 @[DspReal.scala 102:36]
+    BBFSubtract_22_1.out is invalid
+    BBFSubtract_22_1.in2 is invalid
+    BBFSubtract_22_1.in1 is invalid
+    BBFSubtract_22_1.in1 <= _T_3787.node @[DspReal.scala 81:21]
+    BBFSubtract_22_1.in2 <= _T_3781.node @[DspReal.scala 82:21]
+    wire _T_3794 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3794 is invalid @[DspReal.scala 83:19]
+    _T_3794.node <= BBFSubtract_22_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_30_1 of BBFAdd_30 @[DspReal.scala 98:36]
+    BBFAdd_30_1.out is invalid
+    BBFAdd_30_1.in2 is invalid
+    BBFAdd_30_1.in1 is invalid
+    BBFAdd_30_1.in1 <= _T_3775.node @[DspReal.scala 81:21]
+    BBFAdd_30_1.in2 <= _T_3794.node @[DspReal.scala 82:21]
+    wire _T_3800 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3800 is invalid @[DspReal.scala 83:19]
+    _T_3800.node <= BBFAdd_30_1.out @[DspReal.scala 84:14]
+    inst BBFMultiply_22_1 of BBFMultiply_22 @[DspReal.scala 106:36]
+    BBFMultiply_22_1.out is invalid
+    BBFMultiply_22_1.in2 is invalid
+    BBFMultiply_22_1.in1 is invalid
+    BBFMultiply_22_1.in1 <= stage_outputs_1_3.real.node @[DspReal.scala 81:21]
+    BBFMultiply_22_1.in2 <= _T_3771.imaginary.node @[DspReal.scala 82:21]
+    wire _T_3806 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3806 is invalid @[DspReal.scala 83:19]
+    _T_3806.node <= BBFMultiply_22_1.out @[DspReal.scala 84:14]
+    inst BBFMultiply_23_1 of BBFMultiply_23 @[DspReal.scala 106:36]
+    BBFMultiply_23_1.out is invalid
+    BBFMultiply_23_1.in2 is invalid
+    BBFMultiply_23_1.in1 is invalid
+    BBFMultiply_23_1.in1 <= stage_outputs_1_3.imaginary.node @[DspReal.scala 81:21]
+    BBFMultiply_23_1.in2 <= _T_3771.real.node @[DspReal.scala 82:21]
+    wire _T_3812 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3812 is invalid @[DspReal.scala 83:19]
+    _T_3812.node <= BBFMultiply_23_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_31_1 of BBFAdd_31 @[DspReal.scala 98:36]
+    BBFAdd_31_1.out is invalid
+    BBFAdd_31_1.in2 is invalid
+    BBFAdd_31_1.in1 is invalid
+    BBFAdd_31_1.in1 <= _T_3806.node @[DspReal.scala 81:21]
+    BBFAdd_31_1.in2 <= _T_3812.node @[DspReal.scala 82:21]
+    wire _T_3818 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3818 is invalid @[DspReal.scala 83:19]
+    _T_3818.node <= BBFAdd_31_1.out @[DspReal.scala 84:14]
+    wire _T_3834 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_3834 is invalid @[DspComplex.scala 14:22]
+    _T_3834.real.node <= _T_3800.node @[DspComplex.scala 15:17]
+    _T_3834.imaginary.node <= _T_3818.node @[DspComplex.scala 16:22]
+    inst BBFAdd_32_1 of BBFAdd_32 @[DspReal.scala 98:36]
+    BBFAdd_32_1.out is invalid
+    BBFAdd_32_1.in2 is invalid
+    BBFAdd_32_1.in1 is invalid
+    BBFAdd_32_1.in1 <= stage_outputs_1_1.real.node @[DspReal.scala 81:21]
+    BBFAdd_32_1.in2 <= _T_3834.real.node @[DspReal.scala 82:21]
+    wire _T_3838 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3838 is invalid @[DspReal.scala 83:19]
+    _T_3838.node <= BBFAdd_32_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_33_1 of BBFAdd_33 @[DspReal.scala 98:36]
+    BBFAdd_33_1.out is invalid
+    BBFAdd_33_1.in2 is invalid
+    BBFAdd_33_1.in1 is invalid
+    BBFAdd_33_1.in1 <= stage_outputs_1_1.imaginary.node @[DspReal.scala 81:21]
+    BBFAdd_33_1.in2 <= _T_3834.imaginary.node @[DspReal.scala 82:21]
+    wire _T_3844 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3844 is invalid @[DspReal.scala 83:19]
+    _T_3844.node <= BBFAdd_33_1.out @[DspReal.scala 84:14]
+    wire _T_3860 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_3860 is invalid @[DspComplex.scala 14:22]
+    _T_3860.real.node <= _T_3838.node @[DspComplex.scala 15:17]
+    _T_3860.imaginary.node <= _T_3844.node @[DspComplex.scala 16:22]
+    wire _T_3864 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_3864 is invalid @[DspReal.scala 165:19]
+    _T_3864.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    inst BBFSubtract_23_1 of BBFSubtract_23 @[DspReal.scala 102:36]
+    BBFSubtract_23_1.out is invalid
+    BBFSubtract_23_1.in2 is invalid
+    BBFSubtract_23_1.in1 is invalid
+    BBFSubtract_23_1.in1 <= _T_3864.node @[DspReal.scala 81:21]
+    BBFSubtract_23_1.in2 <= _T_3834.real.node @[DspReal.scala 82:21]
+    wire _T_3871 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3871 is invalid @[DspReal.scala 83:19]
+    _T_3871.node <= BBFSubtract_23_1.out @[DspReal.scala 84:14]
+    wire _T_3877 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_3877 is invalid @[DspReal.scala 165:19]
+    _T_3877.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    inst BBFSubtract_24_1 of BBFSubtract_24 @[DspReal.scala 102:36]
+    BBFSubtract_24_1.out is invalid
+    BBFSubtract_24_1.in2 is invalid
+    BBFSubtract_24_1.in1 is invalid
+    BBFSubtract_24_1.in1 <= _T_3877.node @[DspReal.scala 81:21]
+    BBFSubtract_24_1.in2 <= _T_3834.imaginary.node @[DspReal.scala 82:21]
+    wire _T_3884 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3884 is invalid @[DspReal.scala 83:19]
+    _T_3884.node <= BBFSubtract_24_1.out @[DspReal.scala 84:14]
+    wire _T_3900 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_3900 is invalid @[DspComplex.scala 14:22]
+    _T_3900.real.node <= _T_3871.node @[DspComplex.scala 15:17]
+    _T_3900.imaginary.node <= _T_3884.node @[DspComplex.scala 16:22]
+    inst BBFAdd_34_1 of BBFAdd_34 @[DspReal.scala 98:36]
+    BBFAdd_34_1.out is invalid
+    BBFAdd_34_1.in2 is invalid
+    BBFAdd_34_1.in1 is invalid
+    BBFAdd_34_1.in1 <= stage_outputs_1_1.real.node @[DspReal.scala 81:21]
+    BBFAdd_34_1.in2 <= _T_3900.real.node @[DspReal.scala 82:21]
+    wire _T_3904 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3904 is invalid @[DspReal.scala 83:19]
+    _T_3904.node <= BBFAdd_34_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_35_1 of BBFAdd_35 @[DspReal.scala 98:36]
+    BBFAdd_35_1.out is invalid
+    BBFAdd_35_1.in2 is invalid
+    BBFAdd_35_1.in1 is invalid
+    BBFAdd_35_1.in1 <= stage_outputs_1_1.imaginary.node @[DspReal.scala 81:21]
+    BBFAdd_35_1.in2 <= _T_3900.imaginary.node @[DspReal.scala 82:21]
+    wire _T_3910 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3910 is invalid @[DspReal.scala 83:19]
+    _T_3910.node <= BBFAdd_35_1.out @[DspReal.scala 84:14]
+    wire _T_3926 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_3926 is invalid @[DspComplex.scala 14:22]
+    _T_3926.real.node <= _T_3904.node @[DspComplex.scala 15:17]
+    _T_3926.imaginary.node <= _T_3910.node @[DspComplex.scala 16:22]
+    cmem _T_3941 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[1] @[FFTUtilities.scala 169:21]
+    when io.in.valid : @[Counter.scala 59:17]
+      skip @[Counter.scala 59:17]
+    node _T_3944 = and(io.in.valid, UInt<1>("h01")) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_3952 = _T_3941[UInt<1>("h00")], clock
+      _T_3952.imaginary.node <= _T_3860.imaginary.node @[FFTUtilities.scala 172:29]
+      _T_3952.real.node <= _T_3860.real.node @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_3960 = _T_3941[UInt<1>("h00")], clock
+    stage_outputs_2_1.imaginary.node <= _T_3960.imaginary.node @[FFT.scala 75:14]
+    stage_outputs_2_1.real.node <= _T_3960.real.node @[FFT.scala 75:14]
+    cmem _T_3975 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[1] @[FFTUtilities.scala 169:21]
+    when io.in.valid : @[Counter.scala 59:17]
+      skip @[Counter.scala 59:17]
+    node _T_3978 = and(io.in.valid, UInt<1>("h01")) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_3986 = _T_3975[UInt<1>("h00")], clock
+      _T_3986.imaginary.node <= _T_3926.imaginary.node @[FFTUtilities.scala 172:29]
+      _T_3986.real.node <= _T_3926.real.node @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_3994 = _T_3975[UInt<1>("h00")], clock
+    stage_outputs_2_3.imaginary.node <= _T_3994.imaginary.node @[FFT.scala 75:14]
+    stage_outputs_2_3.real.node <= _T_3994.real.node @[FFT.scala 75:14]
+    cmem _T_4009 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[1] @[FFTUtilities.scala 169:21]
+    when io.in.valid : @[Counter.scala 59:17]
+      skip @[Counter.scala 59:17]
+    node _T_4012 = and(io.in.valid, UInt<1>("h01")) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_4020 = _T_4009[UInt<1>("h00")], clock
+      _T_4020.imaginary.node <= twiddle[4].imaginary.node @[FFTUtilities.scala 172:29]
+      _T_4020.real.node <= twiddle[4].real.node @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_4028 = _T_4009[UInt<1>("h00")], clock
+    inst BBFMultiply_24_1 of BBFMultiply_24 @[DspReal.scala 106:36]
+    BBFMultiply_24_1.out is invalid
+    BBFMultiply_24_1.in2 is invalid
+    BBFMultiply_24_1.in1 is invalid
+    BBFMultiply_24_1.in1 <= stage_outputs_1_6.real.node @[DspReal.scala 81:21]
+    BBFMultiply_24_1.in2 <= _T_4028.real.node @[DspReal.scala 82:21]
+    wire _T_4032 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_4032 is invalid @[DspReal.scala 83:19]
+    _T_4032.node <= BBFMultiply_24_1.out @[DspReal.scala 84:14]
+    inst BBFMultiply_25_1 of BBFMultiply_25 @[DspReal.scala 106:36]
+    BBFMultiply_25_1.out is invalid
+    BBFMultiply_25_1.in2 is invalid
+    BBFMultiply_25_1.in1 is invalid
+    BBFMultiply_25_1.in1 <= stage_outputs_1_6.imaginary.node @[DspReal.scala 81:21]
+    BBFMultiply_25_1.in2 <= _T_4028.imaginary.node @[DspReal.scala 82:21]
+    wire _T_4038 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_4038 is invalid @[DspReal.scala 83:19]
+    _T_4038.node <= BBFMultiply_25_1.out @[DspReal.scala 84:14]
+    wire _T_4044 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_4044 is invalid @[DspReal.scala 165:19]
+    _T_4044.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    inst BBFSubtract_25_1 of BBFSubtract_25 @[DspReal.scala 102:36]
+    BBFSubtract_25_1.out is invalid
+    BBFSubtract_25_1.in2 is invalid
+    BBFSubtract_25_1.in1 is invalid
+    BBFSubtract_25_1.in1 <= _T_4044.node @[DspReal.scala 81:21]
+    BBFSubtract_25_1.in2 <= _T_4038.node @[DspReal.scala 82:21]
+    wire _T_4051 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_4051 is invalid @[DspReal.scala 83:19]
+    _T_4051.node <= BBFSubtract_25_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_36_1 of BBFAdd_36 @[DspReal.scala 98:36]
+    BBFAdd_36_1.out is invalid
+    BBFAdd_36_1.in2 is invalid
+    BBFAdd_36_1.in1 is invalid
+    BBFAdd_36_1.in1 <= _T_4032.node @[DspReal.scala 81:21]
+    BBFAdd_36_1.in2 <= _T_4051.node @[DspReal.scala 82:21]
+    wire _T_4057 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_4057 is invalid @[DspReal.scala 83:19]
+    _T_4057.node <= BBFAdd_36_1.out @[DspReal.scala 84:14]
+    inst BBFMultiply_26_1 of BBFMultiply_26 @[DspReal.scala 106:36]
+    BBFMultiply_26_1.out is invalid
+    BBFMultiply_26_1.in2 is invalid
+    BBFMultiply_26_1.in1 is invalid
+    BBFMultiply_26_1.in1 <= stage_outputs_1_6.real.node @[DspReal.scala 81:21]
+    BBFMultiply_26_1.in2 <= _T_4028.imaginary.node @[DspReal.scala 82:21]
+    wire _T_4063 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_4063 is invalid @[DspReal.scala 83:19]
+    _T_4063.node <= BBFMultiply_26_1.out @[DspReal.scala 84:14]
+    inst BBFMultiply_27_1 of BBFMultiply_27 @[DspReal.scala 106:36]
+    BBFMultiply_27_1.out is invalid
+    BBFMultiply_27_1.in2 is invalid
+    BBFMultiply_27_1.in1 is invalid
+    BBFMultiply_27_1.in1 <= stage_outputs_1_6.imaginary.node @[DspReal.scala 81:21]
+    BBFMultiply_27_1.in2 <= _T_4028.real.node @[DspReal.scala 82:21]
+    wire _T_4069 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_4069 is invalid @[DspReal.scala 83:19]
+    _T_4069.node <= BBFMultiply_27_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_37_1 of BBFAdd_37 @[DspReal.scala 98:36]
+    BBFAdd_37_1.out is invalid
+    BBFAdd_37_1.in2 is invalid
+    BBFAdd_37_1.in1 is invalid
+    BBFAdd_37_1.in1 <= _T_4063.node @[DspReal.scala 81:21]
+    BBFAdd_37_1.in2 <= _T_4069.node @[DspReal.scala 82:21]
+    wire _T_4075 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_4075 is invalid @[DspReal.scala 83:19]
+    _T_4075.node <= BBFAdd_37_1.out @[DspReal.scala 84:14]
+    wire _T_4091 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_4091 is invalid @[DspComplex.scala 14:22]
+    _T_4091.real.node <= _T_4057.node @[DspComplex.scala 15:17]
+    _T_4091.imaginary.node <= _T_4075.node @[DspComplex.scala 16:22]
+    inst BBFAdd_38_1 of BBFAdd_38 @[DspReal.scala 98:36]
+    BBFAdd_38_1.out is invalid
+    BBFAdd_38_1.in2 is invalid
+    BBFAdd_38_1.in1 is invalid
+    BBFAdd_38_1.in1 <= stage_outputs_1_4.real.node @[DspReal.scala 81:21]
+    BBFAdd_38_1.in2 <= _T_4091.real.node @[DspReal.scala 82:21]
+    wire _T_4095 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_4095 is invalid @[DspReal.scala 83:19]
+    _T_4095.node <= BBFAdd_38_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_39_1 of BBFAdd_39 @[DspReal.scala 98:36]
+    BBFAdd_39_1.out is invalid
+    BBFAdd_39_1.in2 is invalid
+    BBFAdd_39_1.in1 is invalid
+    BBFAdd_39_1.in1 <= stage_outputs_1_4.imaginary.node @[DspReal.scala 81:21]
+    BBFAdd_39_1.in2 <= _T_4091.imaginary.node @[DspReal.scala 82:21]
+    wire _T_4101 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_4101 is invalid @[DspReal.scala 83:19]
+    _T_4101.node <= BBFAdd_39_1.out @[DspReal.scala 84:14]
+    wire _T_4117 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_4117 is invalid @[DspComplex.scala 14:22]
+    _T_4117.real.node <= _T_4095.node @[DspComplex.scala 15:17]
+    _T_4117.imaginary.node <= _T_4101.node @[DspComplex.scala 16:22]
+    wire _T_4121 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_4121 is invalid @[DspReal.scala 165:19]
+    _T_4121.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    inst BBFSubtract_26_1 of BBFSubtract_26 @[DspReal.scala 102:36]
+    BBFSubtract_26_1.out is invalid
+    BBFSubtract_26_1.in2 is invalid
+    BBFSubtract_26_1.in1 is invalid
+    BBFSubtract_26_1.in1 <= _T_4121.node @[DspReal.scala 81:21]
+    BBFSubtract_26_1.in2 <= _T_4091.real.node @[DspReal.scala 82:21]
+    wire _T_4128 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_4128 is invalid @[DspReal.scala 83:19]
+    _T_4128.node <= BBFSubtract_26_1.out @[DspReal.scala 84:14]
+    wire _T_4134 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_4134 is invalid @[DspReal.scala 165:19]
+    _T_4134.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    inst BBFSubtract_27_1 of BBFSubtract_27 @[DspReal.scala 102:36]
+    BBFSubtract_27_1.out is invalid
+    BBFSubtract_27_1.in2 is invalid
+    BBFSubtract_27_1.in1 is invalid
+    BBFSubtract_27_1.in1 <= _T_4134.node @[DspReal.scala 81:21]
+    BBFSubtract_27_1.in2 <= _T_4091.imaginary.node @[DspReal.scala 82:21]
+    wire _T_4141 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_4141 is invalid @[DspReal.scala 83:19]
+    _T_4141.node <= BBFSubtract_27_1.out @[DspReal.scala 84:14]
+    wire _T_4157 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_4157 is invalid @[DspComplex.scala 14:22]
+    _T_4157.real.node <= _T_4128.node @[DspComplex.scala 15:17]
+    _T_4157.imaginary.node <= _T_4141.node @[DspComplex.scala 16:22]
+    inst BBFAdd_40_1 of BBFAdd_40 @[DspReal.scala 98:36]
+    BBFAdd_40_1.out is invalid
+    BBFAdd_40_1.in2 is invalid
+    BBFAdd_40_1.in1 is invalid
+    BBFAdd_40_1.in1 <= stage_outputs_1_4.real.node @[DspReal.scala 81:21]
+    BBFAdd_40_1.in2 <= _T_4157.real.node @[DspReal.scala 82:21]
+    wire _T_4161 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_4161 is invalid @[DspReal.scala 83:19]
+    _T_4161.node <= BBFAdd_40_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_41_1 of BBFAdd_41 @[DspReal.scala 98:36]
+    BBFAdd_41_1.out is invalid
+    BBFAdd_41_1.in2 is invalid
+    BBFAdd_41_1.in1 is invalid
+    BBFAdd_41_1.in1 <= stage_outputs_1_4.imaginary.node @[DspReal.scala 81:21]
+    BBFAdd_41_1.in2 <= _T_4157.imaginary.node @[DspReal.scala 82:21]
+    wire _T_4167 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_4167 is invalid @[DspReal.scala 83:19]
+    _T_4167.node <= BBFAdd_41_1.out @[DspReal.scala 84:14]
+    wire _T_4183 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_4183 is invalid @[DspComplex.scala 14:22]
+    _T_4183.real.node <= _T_4161.node @[DspComplex.scala 15:17]
+    _T_4183.imaginary.node <= _T_4167.node @[DspComplex.scala 16:22]
+    cmem _T_4198 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[1] @[FFTUtilities.scala 169:21]
+    when io.in.valid : @[Counter.scala 59:17]
+      skip @[Counter.scala 59:17]
+    node _T_4201 = and(io.in.valid, UInt<1>("h01")) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_4209 = _T_4198[UInt<1>("h00")], clock
+      _T_4209.imaginary.node <= _T_4117.imaginary.node @[FFTUtilities.scala 172:29]
+      _T_4209.real.node <= _T_4117.real.node @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_4217 = _T_4198[UInt<1>("h00")], clock
+    stage_outputs_2_4.imaginary.node <= _T_4217.imaginary.node @[FFT.scala 75:14]
+    stage_outputs_2_4.real.node <= _T_4217.real.node @[FFT.scala 75:14]
+    cmem _T_4232 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[1] @[FFTUtilities.scala 169:21]
+    when io.in.valid : @[Counter.scala 59:17]
+      skip @[Counter.scala 59:17]
+    node _T_4235 = and(io.in.valid, UInt<1>("h01")) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_4243 = _T_4232[UInt<1>("h00")], clock
+      _T_4243.imaginary.node <= _T_4183.imaginary.node @[FFTUtilities.scala 172:29]
+      _T_4243.real.node <= _T_4183.real.node @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_4251 = _T_4232[UInt<1>("h00")], clock
+    stage_outputs_2_6.imaginary.node <= _T_4251.imaginary.node @[FFT.scala 75:14]
+    stage_outputs_2_6.real.node <= _T_4251.real.node @[FFT.scala 75:14]
+    cmem _T_4266 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[1] @[FFTUtilities.scala 169:21]
+    when io.in.valid : @[Counter.scala 59:17]
+      skip @[Counter.scala 59:17]
+    node _T_4269 = and(io.in.valid, UInt<1>("h01")) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_4277 = _T_4266[UInt<1>("h00")], clock
+      _T_4277.imaginary.node <= twiddle[4].imaginary.node @[FFTUtilities.scala 172:29]
+      _T_4277.real.node <= twiddle[4].real.node @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_4285 = _T_4266[UInt<1>("h00")], clock
+    inst BBFMultiply_28_1 of BBFMultiply_28 @[DspReal.scala 106:36]
+    BBFMultiply_28_1.out is invalid
+    BBFMultiply_28_1.in2 is invalid
+    BBFMultiply_28_1.in1 is invalid
+    BBFMultiply_28_1.in1 <= stage_outputs_1_7.real.node @[DspReal.scala 81:21]
+    BBFMultiply_28_1.in2 <= _T_4285.real.node @[DspReal.scala 82:21]
+    wire _T_4289 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_4289 is invalid @[DspReal.scala 83:19]
+    _T_4289.node <= BBFMultiply_28_1.out @[DspReal.scala 84:14]
+    inst BBFMultiply_29_1 of BBFMultiply_29 @[DspReal.scala 106:36]
+    BBFMultiply_29_1.out is invalid
+    BBFMultiply_29_1.in2 is invalid
+    BBFMultiply_29_1.in1 is invalid
+    BBFMultiply_29_1.in1 <= stage_outputs_1_7.imaginary.node @[DspReal.scala 81:21]
+    BBFMultiply_29_1.in2 <= _T_4285.imaginary.node @[DspReal.scala 82:21]
+    wire _T_4295 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_4295 is invalid @[DspReal.scala 83:19]
+    _T_4295.node <= BBFMultiply_29_1.out @[DspReal.scala 84:14]
+    wire _T_4301 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_4301 is invalid @[DspReal.scala 165:19]
+    _T_4301.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    inst BBFSubtract_28_1 of BBFSubtract_28 @[DspReal.scala 102:36]
+    BBFSubtract_28_1.out is invalid
+    BBFSubtract_28_1.in2 is invalid
+    BBFSubtract_28_1.in1 is invalid
+    BBFSubtract_28_1.in1 <= _T_4301.node @[DspReal.scala 81:21]
+    BBFSubtract_28_1.in2 <= _T_4295.node @[DspReal.scala 82:21]
+    wire _T_4308 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_4308 is invalid @[DspReal.scala 83:19]
+    _T_4308.node <= BBFSubtract_28_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_42_1 of BBFAdd_42 @[DspReal.scala 98:36]
+    BBFAdd_42_1.out is invalid
+    BBFAdd_42_1.in2 is invalid
+    BBFAdd_42_1.in1 is invalid
+    BBFAdd_42_1.in1 <= _T_4289.node @[DspReal.scala 81:21]
+    BBFAdd_42_1.in2 <= _T_4308.node @[DspReal.scala 82:21]
+    wire _T_4314 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_4314 is invalid @[DspReal.scala 83:19]
+    _T_4314.node <= BBFAdd_42_1.out @[DspReal.scala 84:14]
+    inst BBFMultiply_30_1 of BBFMultiply_30 @[DspReal.scala 106:36]
+    BBFMultiply_30_1.out is invalid
+    BBFMultiply_30_1.in2 is invalid
+    BBFMultiply_30_1.in1 is invalid
+    BBFMultiply_30_1.in1 <= stage_outputs_1_7.real.node @[DspReal.scala 81:21]
+    BBFMultiply_30_1.in2 <= _T_4285.imaginary.node @[DspReal.scala 82:21]
+    wire _T_4320 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_4320 is invalid @[DspReal.scala 83:19]
+    _T_4320.node <= BBFMultiply_30_1.out @[DspReal.scala 84:14]
+    inst BBFMultiply_31_1 of BBFMultiply_31 @[DspReal.scala 106:36]
+    BBFMultiply_31_1.out is invalid
+    BBFMultiply_31_1.in2 is invalid
+    BBFMultiply_31_1.in1 is invalid
+    BBFMultiply_31_1.in1 <= stage_outputs_1_7.imaginary.node @[DspReal.scala 81:21]
+    BBFMultiply_31_1.in2 <= _T_4285.real.node @[DspReal.scala 82:21]
+    wire _T_4326 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_4326 is invalid @[DspReal.scala 83:19]
+    _T_4326.node <= BBFMultiply_31_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_43_1 of BBFAdd_43 @[DspReal.scala 98:36]
+    BBFAdd_43_1.out is invalid
+    BBFAdd_43_1.in2 is invalid
+    BBFAdd_43_1.in1 is invalid
+    BBFAdd_43_1.in1 <= _T_4320.node @[DspReal.scala 81:21]
+    BBFAdd_43_1.in2 <= _T_4326.node @[DspReal.scala 82:21]
+    wire _T_4332 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_4332 is invalid @[DspReal.scala 83:19]
+    _T_4332.node <= BBFAdd_43_1.out @[DspReal.scala 84:14]
+    wire _T_4348 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_4348 is invalid @[DspComplex.scala 14:22]
+    _T_4348.real.node <= _T_4314.node @[DspComplex.scala 15:17]
+    _T_4348.imaginary.node <= _T_4332.node @[DspComplex.scala 16:22]
+    inst BBFAdd_44_1 of BBFAdd_44 @[DspReal.scala 98:36]
+    BBFAdd_44_1.out is invalid
+    BBFAdd_44_1.in2 is invalid
+    BBFAdd_44_1.in1 is invalid
+    BBFAdd_44_1.in1 <= stage_outputs_1_5.real.node @[DspReal.scala 81:21]
+    BBFAdd_44_1.in2 <= _T_4348.real.node @[DspReal.scala 82:21]
+    wire _T_4352 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_4352 is invalid @[DspReal.scala 83:19]
+    _T_4352.node <= BBFAdd_44_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_45_1 of BBFAdd_45 @[DspReal.scala 98:36]
+    BBFAdd_45_1.out is invalid
+    BBFAdd_45_1.in2 is invalid
+    BBFAdd_45_1.in1 is invalid
+    BBFAdd_45_1.in1 <= stage_outputs_1_5.imaginary.node @[DspReal.scala 81:21]
+    BBFAdd_45_1.in2 <= _T_4348.imaginary.node @[DspReal.scala 82:21]
+    wire _T_4358 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_4358 is invalid @[DspReal.scala 83:19]
+    _T_4358.node <= BBFAdd_45_1.out @[DspReal.scala 84:14]
+    wire _T_4374 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_4374 is invalid @[DspComplex.scala 14:22]
+    _T_4374.real.node <= _T_4352.node @[DspComplex.scala 15:17]
+    _T_4374.imaginary.node <= _T_4358.node @[DspComplex.scala 16:22]
+    wire _T_4378 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_4378 is invalid @[DspReal.scala 165:19]
+    _T_4378.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    inst BBFSubtract_29_1 of BBFSubtract_29 @[DspReal.scala 102:36]
+    BBFSubtract_29_1.out is invalid
+    BBFSubtract_29_1.in2 is invalid
+    BBFSubtract_29_1.in1 is invalid
+    BBFSubtract_29_1.in1 <= _T_4378.node @[DspReal.scala 81:21]
+    BBFSubtract_29_1.in2 <= _T_4348.real.node @[DspReal.scala 82:21]
+    wire _T_4385 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_4385 is invalid @[DspReal.scala 83:19]
+    _T_4385.node <= BBFSubtract_29_1.out @[DspReal.scala 84:14]
+    wire _T_4391 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_4391 is invalid @[DspReal.scala 165:19]
+    _T_4391.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    inst BBFSubtract_30_1 of BBFSubtract_30 @[DspReal.scala 102:36]
+    BBFSubtract_30_1.out is invalid
+    BBFSubtract_30_1.in2 is invalid
+    BBFSubtract_30_1.in1 is invalid
+    BBFSubtract_30_1.in1 <= _T_4391.node @[DspReal.scala 81:21]
+    BBFSubtract_30_1.in2 <= _T_4348.imaginary.node @[DspReal.scala 82:21]
+    wire _T_4398 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_4398 is invalid @[DspReal.scala 83:19]
+    _T_4398.node <= BBFSubtract_30_1.out @[DspReal.scala 84:14]
+    wire _T_4414 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_4414 is invalid @[DspComplex.scala 14:22]
+    _T_4414.real.node <= _T_4385.node @[DspComplex.scala 15:17]
+    _T_4414.imaginary.node <= _T_4398.node @[DspComplex.scala 16:22]
+    inst BBFAdd_46_1 of BBFAdd_46 @[DspReal.scala 98:36]
+    BBFAdd_46_1.out is invalid
+    BBFAdd_46_1.in2 is invalid
+    BBFAdd_46_1.in1 is invalid
+    BBFAdd_46_1.in1 <= stage_outputs_1_5.real.node @[DspReal.scala 81:21]
+    BBFAdd_46_1.in2 <= _T_4414.real.node @[DspReal.scala 82:21]
+    wire _T_4418 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_4418 is invalid @[DspReal.scala 83:19]
+    _T_4418.node <= BBFAdd_46_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_47_1 of BBFAdd_47 @[DspReal.scala 98:36]
+    BBFAdd_47_1.out is invalid
+    BBFAdd_47_1.in2 is invalid
+    BBFAdd_47_1.in1 is invalid
+    BBFAdd_47_1.in1 <= stage_outputs_1_5.imaginary.node @[DspReal.scala 81:21]
+    BBFAdd_47_1.in2 <= _T_4414.imaginary.node @[DspReal.scala 82:21]
+    wire _T_4424 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_4424 is invalid @[DspReal.scala 83:19]
+    _T_4424.node <= BBFAdd_47_1.out @[DspReal.scala 84:14]
+    wire _T_4440 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_4440 is invalid @[DspComplex.scala 14:22]
+    _T_4440.real.node <= _T_4418.node @[DspComplex.scala 15:17]
+    _T_4440.imaginary.node <= _T_4424.node @[DspComplex.scala 16:22]
+    cmem _T_4455 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[1] @[FFTUtilities.scala 169:21]
+    when io.in.valid : @[Counter.scala 59:17]
+      skip @[Counter.scala 59:17]
+    node _T_4458 = and(io.in.valid, UInt<1>("h01")) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_4466 = _T_4455[UInt<1>("h00")], clock
+      _T_4466.imaginary.node <= _T_4374.imaginary.node @[FFTUtilities.scala 172:29]
+      _T_4466.real.node <= _T_4374.real.node @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_4474 = _T_4455[UInt<1>("h00")], clock
+    stage_outputs_2_5.imaginary.node <= _T_4474.imaginary.node @[FFT.scala 75:14]
+    stage_outputs_2_5.real.node <= _T_4474.real.node @[FFT.scala 75:14]
+    cmem _T_4489 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[1] @[FFTUtilities.scala 169:21]
+    when io.in.valid : @[Counter.scala 59:17]
+      skip @[Counter.scala 59:17]
+    node _T_4492 = and(io.in.valid, UInt<1>("h01")) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_4500 = _T_4489[UInt<1>("h00")], clock
+      _T_4500.imaginary.node <= _T_4440.imaginary.node @[FFTUtilities.scala 172:29]
+      _T_4500.real.node <= _T_4440.real.node @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_4508 = _T_4489[UInt<1>("h00")], clock
+    stage_outputs_2_7.imaginary.node <= _T_4508.imaginary.node @[FFT.scala 75:14]
+    stage_outputs_2_7.real.node <= _T_4508.real.node @[FFT.scala 75:14]
+    cmem _T_4523 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[2] @[FFTUtilities.scala 169:21]
+    reg _T_4525 : UInt<1>, clock with : (reset => (reset, UInt<1>("h00"))) @[Counter.scala 15:29]
+    when io.in.valid : @[Counter.scala 59:17]
+      node _T_4527 = eq(_T_4525, UInt<1>("h01")) @[Counter.scala 23:24]
+      node _T_4529 = add(_T_4525, UInt<1>("h01")) @[Counter.scala 24:22]
+      node _T_4530 = tail(_T_4529, 1) @[Counter.scala 24:22]
+      _T_4525 <= _T_4530 @[Counter.scala 24:13]
+      skip @[Counter.scala 59:17]
+    node _T_4531 = and(io.in.valid, _T_4527) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_4538 = _T_4523[_T_4525], clock
+      _T_4538.imaginary.node <= twiddle[2].imaginary.node @[FFTUtilities.scala 172:29]
+      _T_4538.real.node <= twiddle[2].real.node @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_4545 = _T_4523[_T_4525], clock
+    inst BBFMultiply_32_1 of BBFMultiply_32 @[DspReal.scala 106:36]
+    BBFMultiply_32_1.out is invalid
+    BBFMultiply_32_1.in2 is invalid
+    BBFMultiply_32_1.in1 is invalid
+    BBFMultiply_32_1.in1 <= stage_outputs_2_1.real.node @[DspReal.scala 81:21]
+    BBFMultiply_32_1.in2 <= _T_4545.real.node @[DspReal.scala 82:21]
+    wire _T_4549 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_4549 is invalid @[DspReal.scala 83:19]
+    _T_4549.node <= BBFMultiply_32_1.out @[DspReal.scala 84:14]
+    inst BBFMultiply_33_1 of BBFMultiply_33 @[DspReal.scala 106:36]
+    BBFMultiply_33_1.out is invalid
+    BBFMultiply_33_1.in2 is invalid
+    BBFMultiply_33_1.in1 is invalid
+    BBFMultiply_33_1.in1 <= stage_outputs_2_1.imaginary.node @[DspReal.scala 81:21]
+    BBFMultiply_33_1.in2 <= _T_4545.imaginary.node @[DspReal.scala 82:21]
+    wire _T_4555 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_4555 is invalid @[DspReal.scala 83:19]
+    _T_4555.node <= BBFMultiply_33_1.out @[DspReal.scala 84:14]
+    wire _T_4561 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_4561 is invalid @[DspReal.scala 165:19]
+    _T_4561.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    inst BBFSubtract_31_1 of BBFSubtract_31 @[DspReal.scala 102:36]
+    BBFSubtract_31_1.out is invalid
+    BBFSubtract_31_1.in2 is invalid
+    BBFSubtract_31_1.in1 is invalid
+    BBFSubtract_31_1.in1 <= _T_4561.node @[DspReal.scala 81:21]
+    BBFSubtract_31_1.in2 <= _T_4555.node @[DspReal.scala 82:21]
+    wire _T_4568 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_4568 is invalid @[DspReal.scala 83:19]
+    _T_4568.node <= BBFSubtract_31_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_48_1 of BBFAdd_48 @[DspReal.scala 98:36]
+    BBFAdd_48_1.out is invalid
+    BBFAdd_48_1.in2 is invalid
+    BBFAdd_48_1.in1 is invalid
+    BBFAdd_48_1.in1 <= _T_4549.node @[DspReal.scala 81:21]
+    BBFAdd_48_1.in2 <= _T_4568.node @[DspReal.scala 82:21]
+    wire _T_4574 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_4574 is invalid @[DspReal.scala 83:19]
+    _T_4574.node <= BBFAdd_48_1.out @[DspReal.scala 84:14]
+    inst BBFMultiply_34_1 of BBFMultiply_34 @[DspReal.scala 106:36]
+    BBFMultiply_34_1.out is invalid
+    BBFMultiply_34_1.in2 is invalid
+    BBFMultiply_34_1.in1 is invalid
+    BBFMultiply_34_1.in1 <= stage_outputs_2_1.real.node @[DspReal.scala 81:21]
+    BBFMultiply_34_1.in2 <= _T_4545.imaginary.node @[DspReal.scala 82:21]
+    wire _T_4580 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_4580 is invalid @[DspReal.scala 83:19]
+    _T_4580.node <= BBFMultiply_34_1.out @[DspReal.scala 84:14]
+    inst BBFMultiply_35_1 of BBFMultiply_35 @[DspReal.scala 106:36]
+    BBFMultiply_35_1.out is invalid
+    BBFMultiply_35_1.in2 is invalid
+    BBFMultiply_35_1.in1 is invalid
+    BBFMultiply_35_1.in1 <= stage_outputs_2_1.imaginary.node @[DspReal.scala 81:21]
+    BBFMultiply_35_1.in2 <= _T_4545.real.node @[DspReal.scala 82:21]
+    wire _T_4586 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_4586 is invalid @[DspReal.scala 83:19]
+    _T_4586.node <= BBFMultiply_35_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_49_1 of BBFAdd_49 @[DspReal.scala 98:36]
+    BBFAdd_49_1.out is invalid
+    BBFAdd_49_1.in2 is invalid
+    BBFAdd_49_1.in1 is invalid
+    BBFAdd_49_1.in1 <= _T_4580.node @[DspReal.scala 81:21]
+    BBFAdd_49_1.in2 <= _T_4586.node @[DspReal.scala 82:21]
+    wire _T_4592 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_4592 is invalid @[DspReal.scala 83:19]
+    _T_4592.node <= BBFAdd_49_1.out @[DspReal.scala 84:14]
+    wire _T_4608 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_4608 is invalid @[DspComplex.scala 14:22]
+    _T_4608.real.node <= _T_4574.node @[DspComplex.scala 15:17]
+    _T_4608.imaginary.node <= _T_4592.node @[DspComplex.scala 16:22]
+    inst BBFAdd_50_1 of BBFAdd_50 @[DspReal.scala 98:36]
+    BBFAdd_50_1.out is invalid
+    BBFAdd_50_1.in2 is invalid
+    BBFAdd_50_1.in1 is invalid
+    BBFAdd_50_1.in1 <= stage_outputs_2_0.real.node @[DspReal.scala 81:21]
+    BBFAdd_50_1.in2 <= _T_4608.real.node @[DspReal.scala 82:21]
+    wire _T_4612 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_4612 is invalid @[DspReal.scala 83:19]
+    _T_4612.node <= BBFAdd_50_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_51_1 of BBFAdd_51 @[DspReal.scala 98:36]
+    BBFAdd_51_1.out is invalid
+    BBFAdd_51_1.in2 is invalid
+    BBFAdd_51_1.in1 is invalid
+    BBFAdd_51_1.in1 <= stage_outputs_2_0.imaginary.node @[DspReal.scala 81:21]
+    BBFAdd_51_1.in2 <= _T_4608.imaginary.node @[DspReal.scala 82:21]
+    wire _T_4618 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_4618 is invalid @[DspReal.scala 83:19]
+    _T_4618.node <= BBFAdd_51_1.out @[DspReal.scala 84:14]
+    wire _T_4634 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_4634 is invalid @[DspComplex.scala 14:22]
+    _T_4634.real.node <= _T_4612.node @[DspComplex.scala 15:17]
+    _T_4634.imaginary.node <= _T_4618.node @[DspComplex.scala 16:22]
+    wire _T_4638 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_4638 is invalid @[DspReal.scala 165:19]
+    _T_4638.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    inst BBFSubtract_32_1 of BBFSubtract_32 @[DspReal.scala 102:36]
+    BBFSubtract_32_1.out is invalid
+    BBFSubtract_32_1.in2 is invalid
+    BBFSubtract_32_1.in1 is invalid
+    BBFSubtract_32_1.in1 <= _T_4638.node @[DspReal.scala 81:21]
+    BBFSubtract_32_1.in2 <= _T_4608.real.node @[DspReal.scala 82:21]
+    wire _T_4645 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_4645 is invalid @[DspReal.scala 83:19]
+    _T_4645.node <= BBFSubtract_32_1.out @[DspReal.scala 84:14]
+    wire _T_4651 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_4651 is invalid @[DspReal.scala 165:19]
+    _T_4651.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    inst BBFSubtract_33_1 of BBFSubtract_33 @[DspReal.scala 102:36]
+    BBFSubtract_33_1.out is invalid
+    BBFSubtract_33_1.in2 is invalid
+    BBFSubtract_33_1.in1 is invalid
+    BBFSubtract_33_1.in1 <= _T_4651.node @[DspReal.scala 81:21]
+    BBFSubtract_33_1.in2 <= _T_4608.imaginary.node @[DspReal.scala 82:21]
+    wire _T_4658 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_4658 is invalid @[DspReal.scala 83:19]
+    _T_4658.node <= BBFSubtract_33_1.out @[DspReal.scala 84:14]
+    wire _T_4674 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_4674 is invalid @[DspComplex.scala 14:22]
+    _T_4674.real.node <= _T_4645.node @[DspComplex.scala 15:17]
+    _T_4674.imaginary.node <= _T_4658.node @[DspComplex.scala 16:22]
+    inst BBFAdd_52_1 of BBFAdd_52 @[DspReal.scala 98:36]
+    BBFAdd_52_1.out is invalid
+    BBFAdd_52_1.in2 is invalid
+    BBFAdd_52_1.in1 is invalid
+    BBFAdd_52_1.in1 <= stage_outputs_2_0.real.node @[DspReal.scala 81:21]
+    BBFAdd_52_1.in2 <= _T_4674.real.node @[DspReal.scala 82:21]
+    wire _T_4678 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_4678 is invalid @[DspReal.scala 83:19]
+    _T_4678.node <= BBFAdd_52_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_53_1 of BBFAdd_53 @[DspReal.scala 98:36]
+    BBFAdd_53_1.out is invalid
+    BBFAdd_53_1.in2 is invalid
+    BBFAdd_53_1.in1 is invalid
+    BBFAdd_53_1.in1 <= stage_outputs_2_0.imaginary.node @[DspReal.scala 81:21]
+    BBFAdd_53_1.in2 <= _T_4674.imaginary.node @[DspReal.scala 82:21]
+    wire _T_4684 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_4684 is invalid @[DspReal.scala 83:19]
+    _T_4684.node <= BBFAdd_53_1.out @[DspReal.scala 84:14]
+    wire _T_4700 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_4700 is invalid @[DspComplex.scala 14:22]
+    _T_4700.real.node <= _T_4678.node @[DspComplex.scala 15:17]
+    _T_4700.imaginary.node <= _T_4684.node @[DspComplex.scala 16:22]
+    cmem _T_4715 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[1] @[FFTUtilities.scala 169:21]
+    when io.in.valid : @[Counter.scala 59:17]
+      skip @[Counter.scala 59:17]
+    node _T_4718 = and(io.in.valid, UInt<1>("h01")) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_4726 = _T_4715[UInt<1>("h00")], clock
+      _T_4726.imaginary.node <= _T_4634.imaginary.node @[FFTUtilities.scala 172:29]
+      _T_4726.real.node <= _T_4634.real.node @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_4734 = _T_4715[UInt<1>("h00")], clock
+    stage_outputs_3_0.imaginary.node <= _T_4734.imaginary.node @[FFT.scala 75:14]
+    stage_outputs_3_0.real.node <= _T_4734.real.node @[FFT.scala 75:14]
+    cmem _T_4749 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[1] @[FFTUtilities.scala 169:21]
+    when io.in.valid : @[Counter.scala 59:17]
+      skip @[Counter.scala 59:17]
+    node _T_4752 = and(io.in.valid, UInt<1>("h01")) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_4760 = _T_4749[UInt<1>("h00")], clock
+      _T_4760.imaginary.node <= _T_4700.imaginary.node @[FFTUtilities.scala 172:29]
+      _T_4760.real.node <= _T_4700.real.node @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_4768 = _T_4749[UInt<1>("h00")], clock
+    stage_outputs_3_1.imaginary.node <= _T_4768.imaginary.node @[FFT.scala 75:14]
+    stage_outputs_3_1.real.node <= _T_4768.real.node @[FFT.scala 75:14]
+    cmem _T_4783 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[2] @[FFTUtilities.scala 169:21]
+    reg _T_4785 : UInt<1>, clock with : (reset => (reset, UInt<1>("h00"))) @[Counter.scala 15:29]
+    when io.in.valid : @[Counter.scala 59:17]
+      node _T_4787 = eq(_T_4785, UInt<1>("h01")) @[Counter.scala 23:24]
+      node _T_4789 = add(_T_4785, UInt<1>("h01")) @[Counter.scala 24:22]
+      node _T_4790 = tail(_T_4789, 1) @[Counter.scala 24:22]
+      _T_4785 <= _T_4790 @[Counter.scala 24:13]
+      skip @[Counter.scala 59:17]
+    node _T_4791 = and(io.in.valid, _T_4787) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_4798 = _T_4783[_T_4785], clock
+      _T_4798.imaginary.node <= twiddle[3].imaginary.node @[FFTUtilities.scala 172:29]
+      _T_4798.real.node <= twiddle[3].real.node @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_4805 = _T_4783[_T_4785], clock
+    inst BBFMultiply_36_1 of BBFMultiply_36 @[DspReal.scala 106:36]
+    BBFMultiply_36_1.out is invalid
+    BBFMultiply_36_1.in2 is invalid
+    BBFMultiply_36_1.in1 is invalid
+    BBFMultiply_36_1.in1 <= stage_outputs_2_3.real.node @[DspReal.scala 81:21]
+    BBFMultiply_36_1.in2 <= _T_4805.real.node @[DspReal.scala 82:21]
+    wire _T_4809 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_4809 is invalid @[DspReal.scala 83:19]
+    _T_4809.node <= BBFMultiply_36_1.out @[DspReal.scala 84:14]
+    inst BBFMultiply_37_1 of BBFMultiply_37 @[DspReal.scala 106:36]
+    BBFMultiply_37_1.out is invalid
+    BBFMultiply_37_1.in2 is invalid
+    BBFMultiply_37_1.in1 is invalid
+    BBFMultiply_37_1.in1 <= stage_outputs_2_3.imaginary.node @[DspReal.scala 81:21]
+    BBFMultiply_37_1.in2 <= _T_4805.imaginary.node @[DspReal.scala 82:21]
+    wire _T_4815 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_4815 is invalid @[DspReal.scala 83:19]
+    _T_4815.node <= BBFMultiply_37_1.out @[DspReal.scala 84:14]
+    wire _T_4821 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_4821 is invalid @[DspReal.scala 165:19]
+    _T_4821.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    inst BBFSubtract_34_1 of BBFSubtract_34 @[DspReal.scala 102:36]
+    BBFSubtract_34_1.out is invalid
+    BBFSubtract_34_1.in2 is invalid
+    BBFSubtract_34_1.in1 is invalid
+    BBFSubtract_34_1.in1 <= _T_4821.node @[DspReal.scala 81:21]
+    BBFSubtract_34_1.in2 <= _T_4815.node @[DspReal.scala 82:21]
+    wire _T_4828 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_4828 is invalid @[DspReal.scala 83:19]
+    _T_4828.node <= BBFSubtract_34_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_54_1 of BBFAdd_54 @[DspReal.scala 98:36]
+    BBFAdd_54_1.out is invalid
+    BBFAdd_54_1.in2 is invalid
+    BBFAdd_54_1.in1 is invalid
+    BBFAdd_54_1.in1 <= _T_4809.node @[DspReal.scala 81:21]
+    BBFAdd_54_1.in2 <= _T_4828.node @[DspReal.scala 82:21]
+    wire _T_4834 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_4834 is invalid @[DspReal.scala 83:19]
+    _T_4834.node <= BBFAdd_54_1.out @[DspReal.scala 84:14]
+    inst BBFMultiply_38_1 of BBFMultiply_38 @[DspReal.scala 106:36]
+    BBFMultiply_38_1.out is invalid
+    BBFMultiply_38_1.in2 is invalid
+    BBFMultiply_38_1.in1 is invalid
+    BBFMultiply_38_1.in1 <= stage_outputs_2_3.real.node @[DspReal.scala 81:21]
+    BBFMultiply_38_1.in2 <= _T_4805.imaginary.node @[DspReal.scala 82:21]
+    wire _T_4840 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_4840 is invalid @[DspReal.scala 83:19]
+    _T_4840.node <= BBFMultiply_38_1.out @[DspReal.scala 84:14]
+    inst BBFMultiply_39_1 of BBFMultiply_39 @[DspReal.scala 106:36]
+    BBFMultiply_39_1.out is invalid
+    BBFMultiply_39_1.in2 is invalid
+    BBFMultiply_39_1.in1 is invalid
+    BBFMultiply_39_1.in1 <= stage_outputs_2_3.imaginary.node @[DspReal.scala 81:21]
+    BBFMultiply_39_1.in2 <= _T_4805.real.node @[DspReal.scala 82:21]
+    wire _T_4846 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_4846 is invalid @[DspReal.scala 83:19]
+    _T_4846.node <= BBFMultiply_39_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_55_1 of BBFAdd_55 @[DspReal.scala 98:36]
+    BBFAdd_55_1.out is invalid
+    BBFAdd_55_1.in2 is invalid
+    BBFAdd_55_1.in1 is invalid
+    BBFAdd_55_1.in1 <= _T_4840.node @[DspReal.scala 81:21]
+    BBFAdd_55_1.in2 <= _T_4846.node @[DspReal.scala 82:21]
+    wire _T_4852 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_4852 is invalid @[DspReal.scala 83:19]
+    _T_4852.node <= BBFAdd_55_1.out @[DspReal.scala 84:14]
+    wire _T_4868 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_4868 is invalid @[DspComplex.scala 14:22]
+    _T_4868.real.node <= _T_4834.node @[DspComplex.scala 15:17]
+    _T_4868.imaginary.node <= _T_4852.node @[DspComplex.scala 16:22]
+    inst BBFAdd_56_1 of BBFAdd_56 @[DspReal.scala 98:36]
+    BBFAdd_56_1.out is invalid
+    BBFAdd_56_1.in2 is invalid
+    BBFAdd_56_1.in1 is invalid
+    BBFAdd_56_1.in1 <= stage_outputs_2_2.real.node @[DspReal.scala 81:21]
+    BBFAdd_56_1.in2 <= _T_4868.real.node @[DspReal.scala 82:21]
+    wire _T_4872 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_4872 is invalid @[DspReal.scala 83:19]
+    _T_4872.node <= BBFAdd_56_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_57_1 of BBFAdd_57 @[DspReal.scala 98:36]
+    BBFAdd_57_1.out is invalid
+    BBFAdd_57_1.in2 is invalid
+    BBFAdd_57_1.in1 is invalid
+    BBFAdd_57_1.in1 <= stage_outputs_2_2.imaginary.node @[DspReal.scala 81:21]
+    BBFAdd_57_1.in2 <= _T_4868.imaginary.node @[DspReal.scala 82:21]
+    wire _T_4878 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_4878 is invalid @[DspReal.scala 83:19]
+    _T_4878.node <= BBFAdd_57_1.out @[DspReal.scala 84:14]
+    wire _T_4894 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_4894 is invalid @[DspComplex.scala 14:22]
+    _T_4894.real.node <= _T_4872.node @[DspComplex.scala 15:17]
+    _T_4894.imaginary.node <= _T_4878.node @[DspComplex.scala 16:22]
+    wire _T_4898 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_4898 is invalid @[DspReal.scala 165:19]
+    _T_4898.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    inst BBFSubtract_35_1 of BBFSubtract_35 @[DspReal.scala 102:36]
+    BBFSubtract_35_1.out is invalid
+    BBFSubtract_35_1.in2 is invalid
+    BBFSubtract_35_1.in1 is invalid
+    BBFSubtract_35_1.in1 <= _T_4898.node @[DspReal.scala 81:21]
+    BBFSubtract_35_1.in2 <= _T_4868.real.node @[DspReal.scala 82:21]
+    wire _T_4905 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_4905 is invalid @[DspReal.scala 83:19]
+    _T_4905.node <= BBFSubtract_35_1.out @[DspReal.scala 84:14]
+    wire _T_4911 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_4911 is invalid @[DspReal.scala 165:19]
+    _T_4911.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    inst BBFSubtract_36_1 of BBFSubtract_36 @[DspReal.scala 102:36]
+    BBFSubtract_36_1.out is invalid
+    BBFSubtract_36_1.in2 is invalid
+    BBFSubtract_36_1.in1 is invalid
+    BBFSubtract_36_1.in1 <= _T_4911.node @[DspReal.scala 81:21]
+    BBFSubtract_36_1.in2 <= _T_4868.imaginary.node @[DspReal.scala 82:21]
+    wire _T_4918 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_4918 is invalid @[DspReal.scala 83:19]
+    _T_4918.node <= BBFSubtract_36_1.out @[DspReal.scala 84:14]
+    wire _T_4934 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_4934 is invalid @[DspComplex.scala 14:22]
+    _T_4934.real.node <= _T_4905.node @[DspComplex.scala 15:17]
+    _T_4934.imaginary.node <= _T_4918.node @[DspComplex.scala 16:22]
+    inst BBFAdd_58_1 of BBFAdd_58 @[DspReal.scala 98:36]
+    BBFAdd_58_1.out is invalid
+    BBFAdd_58_1.in2 is invalid
+    BBFAdd_58_1.in1 is invalid
+    BBFAdd_58_1.in1 <= stage_outputs_2_2.real.node @[DspReal.scala 81:21]
+    BBFAdd_58_1.in2 <= _T_4934.real.node @[DspReal.scala 82:21]
+    wire _T_4938 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_4938 is invalid @[DspReal.scala 83:19]
+    _T_4938.node <= BBFAdd_58_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_59_1 of BBFAdd_59 @[DspReal.scala 98:36]
+    BBFAdd_59_1.out is invalid
+    BBFAdd_59_1.in2 is invalid
+    BBFAdd_59_1.in1 is invalid
+    BBFAdd_59_1.in1 <= stage_outputs_2_2.imaginary.node @[DspReal.scala 81:21]
+    BBFAdd_59_1.in2 <= _T_4934.imaginary.node @[DspReal.scala 82:21]
+    wire _T_4944 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_4944 is invalid @[DspReal.scala 83:19]
+    _T_4944.node <= BBFAdd_59_1.out @[DspReal.scala 84:14]
+    wire _T_4960 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_4960 is invalid @[DspComplex.scala 14:22]
+    _T_4960.real.node <= _T_4938.node @[DspComplex.scala 15:17]
+    _T_4960.imaginary.node <= _T_4944.node @[DspComplex.scala 16:22]
+    cmem _T_4975 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[1] @[FFTUtilities.scala 169:21]
+    when io.in.valid : @[Counter.scala 59:17]
+      skip @[Counter.scala 59:17]
+    node _T_4978 = and(io.in.valid, UInt<1>("h01")) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_4986 = _T_4975[UInt<1>("h00")], clock
+      _T_4986.imaginary.node <= _T_4894.imaginary.node @[FFTUtilities.scala 172:29]
+      _T_4986.real.node <= _T_4894.real.node @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_4994 = _T_4975[UInt<1>("h00")], clock
+    stage_outputs_3_2.imaginary.node <= _T_4994.imaginary.node @[FFT.scala 75:14]
+    stage_outputs_3_2.real.node <= _T_4994.real.node @[FFT.scala 75:14]
+    cmem _T_5009 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[1] @[FFTUtilities.scala 169:21]
+    when io.in.valid : @[Counter.scala 59:17]
+      skip @[Counter.scala 59:17]
+    node _T_5012 = and(io.in.valid, UInt<1>("h01")) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_5020 = _T_5009[UInt<1>("h00")], clock
+      _T_5020.imaginary.node <= _T_4960.imaginary.node @[FFTUtilities.scala 172:29]
+      _T_5020.real.node <= _T_4960.real.node @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_5028 = _T_5009[UInt<1>("h00")], clock
+    stage_outputs_3_3.imaginary.node <= _T_5028.imaginary.node @[FFT.scala 75:14]
+    stage_outputs_3_3.real.node <= _T_5028.real.node @[FFT.scala 75:14]
+    cmem _T_5043 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[2] @[FFTUtilities.scala 169:21]
+    reg _T_5045 : UInt<1>, clock with : (reset => (reset, UInt<1>("h00"))) @[Counter.scala 15:29]
+    when io.in.valid : @[Counter.scala 59:17]
+      node _T_5047 = eq(_T_5045, UInt<1>("h01")) @[Counter.scala 23:24]
+      node _T_5049 = add(_T_5045, UInt<1>("h01")) @[Counter.scala 24:22]
+      node _T_5050 = tail(_T_5049, 1) @[Counter.scala 24:22]
+      _T_5045 <= _T_5050 @[Counter.scala 24:13]
+      skip @[Counter.scala 59:17]
+    node _T_5051 = and(io.in.valid, _T_5047) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_5058 = _T_5043[_T_5045], clock
+      _T_5058.imaginary.node <= twiddle[5].imaginary.node @[FFTUtilities.scala 172:29]
+      _T_5058.real.node <= twiddle[5].real.node @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_5065 = _T_5043[_T_5045], clock
+    inst BBFMultiply_40_1 of BBFMultiply_40 @[DspReal.scala 106:36]
+    BBFMultiply_40_1.out is invalid
+    BBFMultiply_40_1.in2 is invalid
+    BBFMultiply_40_1.in1 is invalid
+    BBFMultiply_40_1.in1 <= stage_outputs_2_5.real.node @[DspReal.scala 81:21]
+    BBFMultiply_40_1.in2 <= _T_5065.real.node @[DspReal.scala 82:21]
+    wire _T_5069 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_5069 is invalid @[DspReal.scala 83:19]
+    _T_5069.node <= BBFMultiply_40_1.out @[DspReal.scala 84:14]
+    inst BBFMultiply_41_1 of BBFMultiply_41 @[DspReal.scala 106:36]
+    BBFMultiply_41_1.out is invalid
+    BBFMultiply_41_1.in2 is invalid
+    BBFMultiply_41_1.in1 is invalid
+    BBFMultiply_41_1.in1 <= stage_outputs_2_5.imaginary.node @[DspReal.scala 81:21]
+    BBFMultiply_41_1.in2 <= _T_5065.imaginary.node @[DspReal.scala 82:21]
+    wire _T_5075 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_5075 is invalid @[DspReal.scala 83:19]
+    _T_5075.node <= BBFMultiply_41_1.out @[DspReal.scala 84:14]
+    wire _T_5081 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_5081 is invalid @[DspReal.scala 165:19]
+    _T_5081.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    inst BBFSubtract_37_1 of BBFSubtract_37 @[DspReal.scala 102:36]
+    BBFSubtract_37_1.out is invalid
+    BBFSubtract_37_1.in2 is invalid
+    BBFSubtract_37_1.in1 is invalid
+    BBFSubtract_37_1.in1 <= _T_5081.node @[DspReal.scala 81:21]
+    BBFSubtract_37_1.in2 <= _T_5075.node @[DspReal.scala 82:21]
+    wire _T_5088 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_5088 is invalid @[DspReal.scala 83:19]
+    _T_5088.node <= BBFSubtract_37_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_60_1 of BBFAdd_60 @[DspReal.scala 98:36]
+    BBFAdd_60_1.out is invalid
+    BBFAdd_60_1.in2 is invalid
+    BBFAdd_60_1.in1 is invalid
+    BBFAdd_60_1.in1 <= _T_5069.node @[DspReal.scala 81:21]
+    BBFAdd_60_1.in2 <= _T_5088.node @[DspReal.scala 82:21]
+    wire _T_5094 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_5094 is invalid @[DspReal.scala 83:19]
+    _T_5094.node <= BBFAdd_60_1.out @[DspReal.scala 84:14]
+    inst BBFMultiply_42_1 of BBFMultiply_42 @[DspReal.scala 106:36]
+    BBFMultiply_42_1.out is invalid
+    BBFMultiply_42_1.in2 is invalid
+    BBFMultiply_42_1.in1 is invalid
+    BBFMultiply_42_1.in1 <= stage_outputs_2_5.real.node @[DspReal.scala 81:21]
+    BBFMultiply_42_1.in2 <= _T_5065.imaginary.node @[DspReal.scala 82:21]
+    wire _T_5100 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_5100 is invalid @[DspReal.scala 83:19]
+    _T_5100.node <= BBFMultiply_42_1.out @[DspReal.scala 84:14]
+    inst BBFMultiply_43_1 of BBFMultiply_43 @[DspReal.scala 106:36]
+    BBFMultiply_43_1.out is invalid
+    BBFMultiply_43_1.in2 is invalid
+    BBFMultiply_43_1.in1 is invalid
+    BBFMultiply_43_1.in1 <= stage_outputs_2_5.imaginary.node @[DspReal.scala 81:21]
+    BBFMultiply_43_1.in2 <= _T_5065.real.node @[DspReal.scala 82:21]
+    wire _T_5106 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_5106 is invalid @[DspReal.scala 83:19]
+    _T_5106.node <= BBFMultiply_43_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_61_1 of BBFAdd_61 @[DspReal.scala 98:36]
+    BBFAdd_61_1.out is invalid
+    BBFAdd_61_1.in2 is invalid
+    BBFAdd_61_1.in1 is invalid
+    BBFAdd_61_1.in1 <= _T_5100.node @[DspReal.scala 81:21]
+    BBFAdd_61_1.in2 <= _T_5106.node @[DspReal.scala 82:21]
+    wire _T_5112 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_5112 is invalid @[DspReal.scala 83:19]
+    _T_5112.node <= BBFAdd_61_1.out @[DspReal.scala 84:14]
+    wire _T_5128 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_5128 is invalid @[DspComplex.scala 14:22]
+    _T_5128.real.node <= _T_5094.node @[DspComplex.scala 15:17]
+    _T_5128.imaginary.node <= _T_5112.node @[DspComplex.scala 16:22]
+    inst BBFAdd_62_1 of BBFAdd_62 @[DspReal.scala 98:36]
+    BBFAdd_62_1.out is invalid
+    BBFAdd_62_1.in2 is invalid
+    BBFAdd_62_1.in1 is invalid
+    BBFAdd_62_1.in1 <= stage_outputs_2_4.real.node @[DspReal.scala 81:21]
+    BBFAdd_62_1.in2 <= _T_5128.real.node @[DspReal.scala 82:21]
+    wire _T_5132 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_5132 is invalid @[DspReal.scala 83:19]
+    _T_5132.node <= BBFAdd_62_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_63_1 of BBFAdd_63 @[DspReal.scala 98:36]
+    BBFAdd_63_1.out is invalid
+    BBFAdd_63_1.in2 is invalid
+    BBFAdd_63_1.in1 is invalid
+    BBFAdd_63_1.in1 <= stage_outputs_2_4.imaginary.node @[DspReal.scala 81:21]
+    BBFAdd_63_1.in2 <= _T_5128.imaginary.node @[DspReal.scala 82:21]
+    wire _T_5138 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_5138 is invalid @[DspReal.scala 83:19]
+    _T_5138.node <= BBFAdd_63_1.out @[DspReal.scala 84:14]
+    wire _T_5154 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_5154 is invalid @[DspComplex.scala 14:22]
+    _T_5154.real.node <= _T_5132.node @[DspComplex.scala 15:17]
+    _T_5154.imaginary.node <= _T_5138.node @[DspComplex.scala 16:22]
+    wire _T_5158 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_5158 is invalid @[DspReal.scala 165:19]
+    _T_5158.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    inst BBFSubtract_38_1 of BBFSubtract_38 @[DspReal.scala 102:36]
+    BBFSubtract_38_1.out is invalid
+    BBFSubtract_38_1.in2 is invalid
+    BBFSubtract_38_1.in1 is invalid
+    BBFSubtract_38_1.in1 <= _T_5158.node @[DspReal.scala 81:21]
+    BBFSubtract_38_1.in2 <= _T_5128.real.node @[DspReal.scala 82:21]
+    wire _T_5165 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_5165 is invalid @[DspReal.scala 83:19]
+    _T_5165.node <= BBFSubtract_38_1.out @[DspReal.scala 84:14]
+    wire _T_5171 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_5171 is invalid @[DspReal.scala 165:19]
+    _T_5171.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    inst BBFSubtract_39_1 of BBFSubtract_39 @[DspReal.scala 102:36]
+    BBFSubtract_39_1.out is invalid
+    BBFSubtract_39_1.in2 is invalid
+    BBFSubtract_39_1.in1 is invalid
+    BBFSubtract_39_1.in1 <= _T_5171.node @[DspReal.scala 81:21]
+    BBFSubtract_39_1.in2 <= _T_5128.imaginary.node @[DspReal.scala 82:21]
+    wire _T_5178 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_5178 is invalid @[DspReal.scala 83:19]
+    _T_5178.node <= BBFSubtract_39_1.out @[DspReal.scala 84:14]
+    wire _T_5194 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_5194 is invalid @[DspComplex.scala 14:22]
+    _T_5194.real.node <= _T_5165.node @[DspComplex.scala 15:17]
+    _T_5194.imaginary.node <= _T_5178.node @[DspComplex.scala 16:22]
+    inst BBFAdd_64_1 of BBFAdd_64 @[DspReal.scala 98:36]
+    BBFAdd_64_1.out is invalid
+    BBFAdd_64_1.in2 is invalid
+    BBFAdd_64_1.in1 is invalid
+    BBFAdd_64_1.in1 <= stage_outputs_2_4.real.node @[DspReal.scala 81:21]
+    BBFAdd_64_1.in2 <= _T_5194.real.node @[DspReal.scala 82:21]
+    wire _T_5198 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_5198 is invalid @[DspReal.scala 83:19]
+    _T_5198.node <= BBFAdd_64_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_65_1 of BBFAdd_65 @[DspReal.scala 98:36]
+    BBFAdd_65_1.out is invalid
+    BBFAdd_65_1.in2 is invalid
+    BBFAdd_65_1.in1 is invalid
+    BBFAdd_65_1.in1 <= stage_outputs_2_4.imaginary.node @[DspReal.scala 81:21]
+    BBFAdd_65_1.in2 <= _T_5194.imaginary.node @[DspReal.scala 82:21]
+    wire _T_5204 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_5204 is invalid @[DspReal.scala 83:19]
+    _T_5204.node <= BBFAdd_65_1.out @[DspReal.scala 84:14]
+    wire _T_5220 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_5220 is invalid @[DspComplex.scala 14:22]
+    _T_5220.real.node <= _T_5198.node @[DspComplex.scala 15:17]
+    _T_5220.imaginary.node <= _T_5204.node @[DspComplex.scala 16:22]
+    cmem _T_5235 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[1] @[FFTUtilities.scala 169:21]
+    when io.in.valid : @[Counter.scala 59:17]
+      skip @[Counter.scala 59:17]
+    node _T_5238 = and(io.in.valid, UInt<1>("h01")) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_5246 = _T_5235[UInt<1>("h00")], clock
+      _T_5246.imaginary.node <= _T_5154.imaginary.node @[FFTUtilities.scala 172:29]
+      _T_5246.real.node <= _T_5154.real.node @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_5254 = _T_5235[UInt<1>("h00")], clock
+    stage_outputs_3_4.imaginary.node <= _T_5254.imaginary.node @[FFT.scala 75:14]
+    stage_outputs_3_4.real.node <= _T_5254.real.node @[FFT.scala 75:14]
+    cmem _T_5269 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[1] @[FFTUtilities.scala 169:21]
+    when io.in.valid : @[Counter.scala 59:17]
+      skip @[Counter.scala 59:17]
+    node _T_5272 = and(io.in.valid, UInt<1>("h01")) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_5280 = _T_5269[UInt<1>("h00")], clock
+      _T_5280.imaginary.node <= _T_5220.imaginary.node @[FFTUtilities.scala 172:29]
+      _T_5280.real.node <= _T_5220.real.node @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_5288 = _T_5269[UInt<1>("h00")], clock
+    stage_outputs_3_5.imaginary.node <= _T_5288.imaginary.node @[FFT.scala 75:14]
+    stage_outputs_3_5.real.node <= _T_5288.real.node @[FFT.scala 75:14]
+    cmem _T_5303 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[2] @[FFTUtilities.scala 169:21]
+    reg _T_5305 : UInt<1>, clock with : (reset => (reset, UInt<1>("h00"))) @[Counter.scala 15:29]
+    when io.in.valid : @[Counter.scala 59:17]
+      node _T_5307 = eq(_T_5305, UInt<1>("h01")) @[Counter.scala 23:24]
+      node _T_5309 = add(_T_5305, UInt<1>("h01")) @[Counter.scala 24:22]
+      node _T_5310 = tail(_T_5309, 1) @[Counter.scala 24:22]
+      _T_5305 <= _T_5310 @[Counter.scala 24:13]
+      skip @[Counter.scala 59:17]
+    node _T_5311 = and(io.in.valid, _T_5307) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_5318 = _T_5303[_T_5305], clock
+      _T_5318.imaginary.node <= twiddle[6].imaginary.node @[FFTUtilities.scala 172:29]
+      _T_5318.real.node <= twiddle[6].real.node @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_5325 = _T_5303[_T_5305], clock
+    inst BBFMultiply_44_1 of BBFMultiply_44 @[DspReal.scala 106:36]
+    BBFMultiply_44_1.out is invalid
+    BBFMultiply_44_1.in2 is invalid
+    BBFMultiply_44_1.in1 is invalid
+    BBFMultiply_44_1.in1 <= stage_outputs_2_7.real.node @[DspReal.scala 81:21]
+    BBFMultiply_44_1.in2 <= _T_5325.real.node @[DspReal.scala 82:21]
+    wire _T_5329 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_5329 is invalid @[DspReal.scala 83:19]
+    _T_5329.node <= BBFMultiply_44_1.out @[DspReal.scala 84:14]
+    inst BBFMultiply_45_1 of BBFMultiply_45 @[DspReal.scala 106:36]
+    BBFMultiply_45_1.out is invalid
+    BBFMultiply_45_1.in2 is invalid
+    BBFMultiply_45_1.in1 is invalid
+    BBFMultiply_45_1.in1 <= stage_outputs_2_7.imaginary.node @[DspReal.scala 81:21]
+    BBFMultiply_45_1.in2 <= _T_5325.imaginary.node @[DspReal.scala 82:21]
+    wire _T_5335 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_5335 is invalid @[DspReal.scala 83:19]
+    _T_5335.node <= BBFMultiply_45_1.out @[DspReal.scala 84:14]
+    wire _T_5341 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_5341 is invalid @[DspReal.scala 165:19]
+    _T_5341.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    inst BBFSubtract_40_1 of BBFSubtract_40 @[DspReal.scala 102:36]
+    BBFSubtract_40_1.out is invalid
+    BBFSubtract_40_1.in2 is invalid
+    BBFSubtract_40_1.in1 is invalid
+    BBFSubtract_40_1.in1 <= _T_5341.node @[DspReal.scala 81:21]
+    BBFSubtract_40_1.in2 <= _T_5335.node @[DspReal.scala 82:21]
+    wire _T_5348 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_5348 is invalid @[DspReal.scala 83:19]
+    _T_5348.node <= BBFSubtract_40_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_66_1 of BBFAdd_66 @[DspReal.scala 98:36]
+    BBFAdd_66_1.out is invalid
+    BBFAdd_66_1.in2 is invalid
+    BBFAdd_66_1.in1 is invalid
+    BBFAdd_66_1.in1 <= _T_5329.node @[DspReal.scala 81:21]
+    BBFAdd_66_1.in2 <= _T_5348.node @[DspReal.scala 82:21]
+    wire _T_5354 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_5354 is invalid @[DspReal.scala 83:19]
+    _T_5354.node <= BBFAdd_66_1.out @[DspReal.scala 84:14]
+    inst BBFMultiply_46_1 of BBFMultiply_46 @[DspReal.scala 106:36]
+    BBFMultiply_46_1.out is invalid
+    BBFMultiply_46_1.in2 is invalid
+    BBFMultiply_46_1.in1 is invalid
+    BBFMultiply_46_1.in1 <= stage_outputs_2_7.real.node @[DspReal.scala 81:21]
+    BBFMultiply_46_1.in2 <= _T_5325.imaginary.node @[DspReal.scala 82:21]
+    wire _T_5360 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_5360 is invalid @[DspReal.scala 83:19]
+    _T_5360.node <= BBFMultiply_46_1.out @[DspReal.scala 84:14]
+    inst BBFMultiply_47_1 of BBFMultiply_47 @[DspReal.scala 106:36]
+    BBFMultiply_47_1.out is invalid
+    BBFMultiply_47_1.in2 is invalid
+    BBFMultiply_47_1.in1 is invalid
+    BBFMultiply_47_1.in1 <= stage_outputs_2_7.imaginary.node @[DspReal.scala 81:21]
+    BBFMultiply_47_1.in2 <= _T_5325.real.node @[DspReal.scala 82:21]
+    wire _T_5366 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_5366 is invalid @[DspReal.scala 83:19]
+    _T_5366.node <= BBFMultiply_47_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_67_1 of BBFAdd_67 @[DspReal.scala 98:36]
+    BBFAdd_67_1.out is invalid
+    BBFAdd_67_1.in2 is invalid
+    BBFAdd_67_1.in1 is invalid
+    BBFAdd_67_1.in1 <= _T_5360.node @[DspReal.scala 81:21]
+    BBFAdd_67_1.in2 <= _T_5366.node @[DspReal.scala 82:21]
+    wire _T_5372 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_5372 is invalid @[DspReal.scala 83:19]
+    _T_5372.node <= BBFAdd_67_1.out @[DspReal.scala 84:14]
+    wire _T_5388 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_5388 is invalid @[DspComplex.scala 14:22]
+    _T_5388.real.node <= _T_5354.node @[DspComplex.scala 15:17]
+    _T_5388.imaginary.node <= _T_5372.node @[DspComplex.scala 16:22]
+    inst BBFAdd_68_1 of BBFAdd_68 @[DspReal.scala 98:36]
+    BBFAdd_68_1.out is invalid
+    BBFAdd_68_1.in2 is invalid
+    BBFAdd_68_1.in1 is invalid
+    BBFAdd_68_1.in1 <= stage_outputs_2_6.real.node @[DspReal.scala 81:21]
+    BBFAdd_68_1.in2 <= _T_5388.real.node @[DspReal.scala 82:21]
+    wire _T_5392 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_5392 is invalid @[DspReal.scala 83:19]
+    _T_5392.node <= BBFAdd_68_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_69_1 of BBFAdd_69 @[DspReal.scala 98:36]
+    BBFAdd_69_1.out is invalid
+    BBFAdd_69_1.in2 is invalid
+    BBFAdd_69_1.in1 is invalid
+    BBFAdd_69_1.in1 <= stage_outputs_2_6.imaginary.node @[DspReal.scala 81:21]
+    BBFAdd_69_1.in2 <= _T_5388.imaginary.node @[DspReal.scala 82:21]
+    wire _T_5398 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_5398 is invalid @[DspReal.scala 83:19]
+    _T_5398.node <= BBFAdd_69_1.out @[DspReal.scala 84:14]
+    wire _T_5414 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_5414 is invalid @[DspComplex.scala 14:22]
+    _T_5414.real.node <= _T_5392.node @[DspComplex.scala 15:17]
+    _T_5414.imaginary.node <= _T_5398.node @[DspComplex.scala 16:22]
+    wire _T_5418 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_5418 is invalid @[DspReal.scala 165:19]
+    _T_5418.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    inst BBFSubtract_41_1 of BBFSubtract_41 @[DspReal.scala 102:36]
+    BBFSubtract_41_1.out is invalid
+    BBFSubtract_41_1.in2 is invalid
+    BBFSubtract_41_1.in1 is invalid
+    BBFSubtract_41_1.in1 <= _T_5418.node @[DspReal.scala 81:21]
+    BBFSubtract_41_1.in2 <= _T_5388.real.node @[DspReal.scala 82:21]
+    wire _T_5425 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_5425 is invalid @[DspReal.scala 83:19]
+    _T_5425.node <= BBFSubtract_41_1.out @[DspReal.scala 84:14]
+    wire _T_5431 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_5431 is invalid @[DspReal.scala 165:19]
+    _T_5431.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    inst BBFSubtract_42_1 of BBFSubtract_42 @[DspReal.scala 102:36]
+    BBFSubtract_42_1.out is invalid
+    BBFSubtract_42_1.in2 is invalid
+    BBFSubtract_42_1.in1 is invalid
+    BBFSubtract_42_1.in1 <= _T_5431.node @[DspReal.scala 81:21]
+    BBFSubtract_42_1.in2 <= _T_5388.imaginary.node @[DspReal.scala 82:21]
+    wire _T_5438 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_5438 is invalid @[DspReal.scala 83:19]
+    _T_5438.node <= BBFSubtract_42_1.out @[DspReal.scala 84:14]
+    wire _T_5454 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_5454 is invalid @[DspComplex.scala 14:22]
+    _T_5454.real.node <= _T_5425.node @[DspComplex.scala 15:17]
+    _T_5454.imaginary.node <= _T_5438.node @[DspComplex.scala 16:22]
+    inst BBFAdd_70_1 of BBFAdd_70 @[DspReal.scala 98:36]
+    BBFAdd_70_1.out is invalid
+    BBFAdd_70_1.in2 is invalid
+    BBFAdd_70_1.in1 is invalid
+    BBFAdd_70_1.in1 <= stage_outputs_2_6.real.node @[DspReal.scala 81:21]
+    BBFAdd_70_1.in2 <= _T_5454.real.node @[DspReal.scala 82:21]
+    wire _T_5458 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_5458 is invalid @[DspReal.scala 83:19]
+    _T_5458.node <= BBFAdd_70_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_71_1 of BBFAdd_71 @[DspReal.scala 98:36]
+    BBFAdd_71_1.out is invalid
+    BBFAdd_71_1.in2 is invalid
+    BBFAdd_71_1.in1 is invalid
+    BBFAdd_71_1.in1 <= stage_outputs_2_6.imaginary.node @[DspReal.scala 81:21]
+    BBFAdd_71_1.in2 <= _T_5454.imaginary.node @[DspReal.scala 82:21]
+    wire _T_5464 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_5464 is invalid @[DspReal.scala 83:19]
+    _T_5464.node <= BBFAdd_71_1.out @[DspReal.scala 84:14]
+    wire _T_5480 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_5480 is invalid @[DspComplex.scala 14:22]
+    _T_5480.real.node <= _T_5458.node @[DspComplex.scala 15:17]
+    _T_5480.imaginary.node <= _T_5464.node @[DspComplex.scala 16:22]
+    cmem _T_5495 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[1] @[FFTUtilities.scala 169:21]
+    when io.in.valid : @[Counter.scala 59:17]
+      skip @[Counter.scala 59:17]
+    node _T_5498 = and(io.in.valid, UInt<1>("h01")) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_5506 = _T_5495[UInt<1>("h00")], clock
+      _T_5506.imaginary.node <= _T_5414.imaginary.node @[FFTUtilities.scala 172:29]
+      _T_5506.real.node <= _T_5414.real.node @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_5514 = _T_5495[UInt<1>("h00")], clock
+    stage_outputs_3_6.imaginary.node <= _T_5514.imaginary.node @[FFT.scala 75:14]
+    stage_outputs_3_6.real.node <= _T_5514.real.node @[FFT.scala 75:14]
+    cmem _T_5529 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[1] @[FFTUtilities.scala 169:21]
+    when io.in.valid : @[Counter.scala 59:17]
+      skip @[Counter.scala 59:17]
+    node _T_5532 = and(io.in.valid, UInt<1>("h01")) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_5540 = _T_5529[UInt<1>("h00")], clock
+      _T_5540.imaginary.node <= _T_5480.imaginary.node @[FFTUtilities.scala 172:29]
+      _T_5540.real.node <= _T_5480.real.node @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_5548 = _T_5529[UInt<1>("h00")], clock
+    stage_outputs_3_7.imaginary.node <= _T_5548.imaginary.node @[FFT.scala 75:14]
+    stage_outputs_3_7.real.node <= _T_5548.real.node @[FFT.scala 75:14]
+    io.out.bits[0].imaginary.node <= stage_outputs_3_0.imaginary.node @[FFT.scala 82:15]
+    io.out.bits[0].real.node <= stage_outputs_3_0.real.node @[FFT.scala 82:15]
+    io.out.bits[1].imaginary.node <= stage_outputs_3_1.imaginary.node @[FFT.scala 82:15]
+    io.out.bits[1].real.node <= stage_outputs_3_1.real.node @[FFT.scala 82:15]
+    io.out.bits[2].imaginary.node <= stage_outputs_3_2.imaginary.node @[FFT.scala 82:15]
+    io.out.bits[2].real.node <= stage_outputs_3_2.real.node @[FFT.scala 82:15]
+    io.out.bits[3].imaginary.node <= stage_outputs_3_3.imaginary.node @[FFT.scala 82:15]
+    io.out.bits[3].real.node <= stage_outputs_3_3.real.node @[FFT.scala 82:15]
+    io.out.bits[4].imaginary.node <= stage_outputs_3_4.imaginary.node @[FFT.scala 82:15]
+    io.out.bits[4].real.node <= stage_outputs_3_4.real.node @[FFT.scala 82:15]
+    io.out.bits[5].imaginary.node <= stage_outputs_3_5.imaginary.node @[FFT.scala 82:15]
+    io.out.bits[5].real.node <= stage_outputs_3_5.real.node @[FFT.scala 82:15]
+    io.out.bits[6].imaginary.node <= stage_outputs_3_6.imaginary.node @[FFT.scala 82:15]
+    io.out.bits[6].real.node <= stage_outputs_3_6.real.node @[FFT.scala 82:15]
+    io.out.bits[7].imaginary.node <= stage_outputs_3_7.imaginary.node @[FFT.scala 82:15]
+    io.out.bits[7].real.node <= stage_outputs_3_7.real.node @[FFT.scala 82:15]
+    
+  extmodule BBFMultiply_48 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFMultiply_49 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFSubtract_43 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFSubtract
+    
+    
+  extmodule BBFAdd_72 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFMultiply_50 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFMultiply_51 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFAdd_73 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFAdd_74 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFAdd_75 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFSubtract_44 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFSubtract
+    
+    
+  extmodule BBFSubtract_45 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFSubtract
+    
+    
+  extmodule BBFAdd_76 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFAdd_77 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFMultiply_52 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFMultiply_53 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFSubtract_46 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFSubtract
+    
+    
+  extmodule BBFAdd_78 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFMultiply_54 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFMultiply_55 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFAdd_79 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFAdd_80 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFAdd_81 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFSubtract_47 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFSubtract
+    
+    
+  extmodule BBFSubtract_48 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFSubtract
+    
+    
+  extmodule BBFAdd_82 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFAdd_83 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFMultiply_56 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFMultiply_57 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFSubtract_49 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFSubtract
+    
+    
+  extmodule BBFAdd_84 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFMultiply_58 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFMultiply_59 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFAdd_85 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFAdd_86 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFAdd_87 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFSubtract_50 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFSubtract
+    
+    
+  extmodule BBFSubtract_51 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFSubtract
+    
+    
+  extmodule BBFAdd_88 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFAdd_89 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFMultiply_60 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFMultiply_61 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFSubtract_52 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFSubtract
+    
+    
+  extmodule BBFAdd_90 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFMultiply_62 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFMultiply_63 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFMultiply
+    
+    
+  extmodule BBFAdd_91 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFAdd_92 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFAdd_93 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFSubtract_53 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFSubtract
+    
+    
+  extmodule BBFSubtract_54 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFSubtract
+    
+    
+  extmodule BBFAdd_94 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  extmodule BBFAdd_95 : 
+    output out : UInt<64>
+    input in2 : UInt<64>
+    input in1 : UInt<64>
+    
+    defname = BBFAdd
+    
+    
+  module BiplexFFT : 
+    input clock : Clock
+    input reset : UInt<1>
+    output io : {flip in : {valid : UInt<1>, bits : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[8], sync : UInt<1>}, out : {valid : UInt<1>, bits : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[8], sync : UInt<1>}}
+    
+    io is invalid
+    io is invalid
+    wire _T_5 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_5 is invalid @[DspReal.scala 165:19]
+    _T_5.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_12 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_12 is invalid @[DspReal.scala 165:19]
+    _T_12.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_316 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_316 is invalid @[DspReal.scala 165:19]
+    _T_316.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_323 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_323 is invalid @[DspReal.scala 165:19]
+    _T_323.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire sync_0 : UInt<1> @[FFT.scala 95:49]
+    sync_0 is invalid @[FFT.scala 95:49]
+    wire sync_1 : UInt<1> @[FFT.scala 95:49]
+    sync_1 is invalid @[FFT.scala 95:49]
+    node _T_626 = and(io.in.sync, io.in.valid) @[FFT.scala 96:66]
+    reg _T_628 : UInt<1>, clock with : (reset => (reset, UInt<1>("h00"))) @[Counter.scala 15:29]
+    when io.in.valid : @[Counter.scala 59:17]
+      node _T_630 = eq(_T_628, UInt<1>("h01")) @[Counter.scala 23:24]
+      node _T_632 = add(_T_628, UInt<1>("h01")) @[Counter.scala 24:22]
+      node _T_633 = tail(_T_632, 1) @[Counter.scala 24:22]
+      _T_628 <= _T_633 @[Counter.scala 24:13]
+      skip @[Counter.scala 59:17]
+    node _T_634 = and(io.in.valid, _T_630) @[Counter.scala 60:20]
+    when _T_626 : @[CounterWithReset.scala 11:31]
+      _T_628 <= UInt<1>("h00") @[CounterWithReset.scala 11:38]
+      skip @[CounterWithReset.scala 11:31]
+    sync_0 <= _T_628 @[FFT.scala 96:11]
+    cmem _T_638 : UInt<1>[1] @[FFTUtilities.scala 169:21]
+    when io.in.valid : @[Counter.scala 59:17]
+      skip @[Counter.scala 59:17]
+    node _T_641 = and(io.in.valid, UInt<1>("h01")) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_643 = _T_638[UInt<1>("h00")], clock
+      _T_643 <= sync_0 @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_645 = _T_638[UInt<1>("h00")], clock
+    sync_1 <= _T_645 @[FFT.scala 97:89]
+    node _T_647 = eq(sync_1, UInt<1>("h01")) @[FFT.scala 98:42]
+    io.out.sync <= _T_647 @[FFT.scala 98:15]
+    io.out.valid <= io.in.valid @[FFT.scala 99:16]
+    wire _T_651 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_651 is invalid @[DspReal.scala 165:19]
+    _T_651.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_658 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_658 is invalid @[DspReal.scala 165:19]
+    _T_658.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire twiddle_rom : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[4] @[FFT.scala 104:25]
+    twiddle_rom is invalid @[FFT.scala 104:25]
+    wire _T_735 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_735 is invalid @[DspReal.scala 165:19]
+    _T_735.node <= UInt<64>("h03ff0000000000000") @[DspReal.scala 166:14]
+    wire _T_742 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_742 is invalid @[DspReal.scala 165:19]
+    _T_742.node <= UInt<64>("h08000000000000000") @[DspReal.scala 166:14]
+    wire _T_759 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_759 is invalid @[DspComplex.scala 14:22]
+    _T_759.real.node <= _T_735.node @[DspComplex.scala 15:17]
+    _T_759.imaginary.node <= _T_742.node @[DspComplex.scala 16:22]
+    twiddle_rom[0].imaginary.node <= _T_759.imaginary.node @[FFT.scala 105:69]
+    twiddle_rom[0].real.node <= _T_759.real.node @[FFT.scala 105:69]
+    wire _T_763 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_763 is invalid @[DspReal.scala 165:19]
+    _T_763.node <= UInt<64>("h03fed906bcf328d46") @[DspReal.scala 166:14]
+    wire _T_770 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_770 is invalid @[DspReal.scala 165:19]
+    _T_770.node <= UInt<64>("h0bfd87de2a6aea963") @[DspReal.scala 166:14]
+    wire _T_787 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_787 is invalid @[DspComplex.scala 14:22]
+    _T_787.real.node <= _T_763.node @[DspComplex.scala 15:17]
+    _T_787.imaginary.node <= _T_770.node @[DspComplex.scala 16:22]
+    twiddle_rom[1].imaginary.node <= _T_787.imaginary.node @[FFT.scala 105:69]
+    twiddle_rom[1].real.node <= _T_787.real.node @[FFT.scala 105:69]
+    wire _T_791 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_791 is invalid @[DspReal.scala 165:19]
+    _T_791.node <= UInt<64>("h03fe6a09e667f3bcd") @[DspReal.scala 166:14]
+    wire _T_798 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_798 is invalid @[DspReal.scala 165:19]
+    _T_798.node <= UInt<64>("h0bfe6a09e667f3bcc") @[DspReal.scala 166:14]
+    wire _T_815 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_815 is invalid @[DspComplex.scala 14:22]
+    _T_815.real.node <= _T_791.node @[DspComplex.scala 15:17]
+    _T_815.imaginary.node <= _T_798.node @[DspComplex.scala 16:22]
+    twiddle_rom[2].imaginary.node <= _T_815.imaginary.node @[FFT.scala 105:69]
+    twiddle_rom[2].real.node <= _T_815.real.node @[FFT.scala 105:69]
+    wire _T_819 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_819 is invalid @[DspReal.scala 165:19]
+    _T_819.node <= UInt<64>("h03fd87de2a6aea964") @[DspReal.scala 166:14]
+    wire _T_826 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_826 is invalid @[DspReal.scala 165:19]
+    _T_826.node <= UInt<64>("h0bfed906bcf328d46") @[DspReal.scala 166:14]
+    wire _T_843 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_843 is invalid @[DspComplex.scala 14:22]
+    _T_843.real.node <= _T_819.node @[DspComplex.scala 15:17]
+    _T_843.imaginary.node <= _T_826.node @[DspComplex.scala 16:22]
+    twiddle_rom[3].imaginary.node <= _T_843.imaginary.node @[FFT.scala 105:69]
+    twiddle_rom[3].real.node <= _T_843.real.node @[FFT.scala 105:69]
+    wire indices_rom : UInt<1>[1] @[FFT.scala 106:24]
+    indices_rom is invalid @[FFT.scala 106:24]
+    indices_rom[0] <= UInt<1>("h00") @[FFT.scala 106:24]
+    node _T_854 = add(UInt<1>("h00"), UInt<1>("h00")) @[FFT.scala 107:91]
+    wire _T_860 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_860 is invalid @[DspReal.scala 165:19]
+    _T_860.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_867 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_867 is invalid @[DspReal.scala 165:19]
+    _T_867.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_884 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 108:49]
+    _T_884 is invalid @[FFT.scala 108:49]
+    wire twiddle : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[1] @[FFT.scala 108:44]
+    twiddle is invalid @[FFT.scala 108:44]
+    twiddle[0].imaginary.node <= _T_884.imaginary.node @[FFT.scala 108:44]
+    twiddle[0].real.node <= _T_884.real.node @[FFT.scala 108:44]
+    wire _T_974 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[1] @[FFT.scala 113:19]
+    _T_974 is invalid @[FFT.scala 113:19]
+    _T_974[0].imaginary.node <= twiddle_rom[indices_rom[UInt<1>("h00")]].imaginary.node @[FFT.scala 113:19]
+    _T_974[0].real.node <= twiddle_rom[indices_rom[UInt<1>("h00")]].real.node @[FFT.scala 113:19]
+    twiddle[0].imaginary.node <= _T_974[0].imaginary.node @[FFT.scala 113:13]
+    twiddle[0].real.node <= _T_974[0].real.node @[FFT.scala 113:13]
+    wire _T_1005 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1005 is invalid @[DspReal.scala 165:19]
+    _T_1005.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_1012 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1012 is invalid @[DspReal.scala 165:19]
+    _T_1012.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire stage_outputs_0_0 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 120:78]
+    stage_outputs_0_0 is invalid @[FFT.scala 120:78]
+    wire _T_1032 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1032 is invalid @[DspReal.scala 165:19]
+    _T_1032.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_1039 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1039 is invalid @[DspReal.scala 165:19]
+    _T_1039.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire stage_outputs_0_1 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 120:78]
+    stage_outputs_0_1 is invalid @[FFT.scala 120:78]
+    wire _T_1059 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1059 is invalid @[DspReal.scala 165:19]
+    _T_1059.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_1066 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1066 is invalid @[DspReal.scala 165:19]
+    _T_1066.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire stage_outputs_0_2 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 120:78]
+    stage_outputs_0_2 is invalid @[FFT.scala 120:78]
+    wire _T_1086 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1086 is invalid @[DspReal.scala 165:19]
+    _T_1086.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_1093 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1093 is invalid @[DspReal.scala 165:19]
+    _T_1093.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire stage_outputs_0_3 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 120:78]
+    stage_outputs_0_3 is invalid @[FFT.scala 120:78]
+    wire _T_1113 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1113 is invalid @[DspReal.scala 165:19]
+    _T_1113.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_1120 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1120 is invalid @[DspReal.scala 165:19]
+    _T_1120.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire stage_outputs_0_4 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 120:78]
+    stage_outputs_0_4 is invalid @[FFT.scala 120:78]
+    wire _T_1140 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1140 is invalid @[DspReal.scala 165:19]
+    _T_1140.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_1147 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1147 is invalid @[DspReal.scala 165:19]
+    _T_1147.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire stage_outputs_0_5 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 120:78]
+    stage_outputs_0_5 is invalid @[FFT.scala 120:78]
+    wire _T_1167 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1167 is invalid @[DspReal.scala 165:19]
+    _T_1167.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_1174 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1174 is invalid @[DspReal.scala 165:19]
+    _T_1174.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire stage_outputs_0_6 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 120:78]
+    stage_outputs_0_6 is invalid @[FFT.scala 120:78]
+    wire _T_1194 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1194 is invalid @[DspReal.scala 165:19]
+    _T_1194.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_1201 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1201 is invalid @[DspReal.scala 165:19]
+    _T_1201.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire stage_outputs_0_7 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 120:78]
+    stage_outputs_0_7 is invalid @[FFT.scala 120:78]
+    wire _T_1221 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1221 is invalid @[DspReal.scala 165:19]
+    _T_1221.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_1228 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1228 is invalid @[DspReal.scala 165:19]
+    _T_1228.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire stage_outputs_1_0 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 120:78]
+    stage_outputs_1_0 is invalid @[FFT.scala 120:78]
+    wire _T_1248 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1248 is invalid @[DspReal.scala 165:19]
+    _T_1248.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_1255 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1255 is invalid @[DspReal.scala 165:19]
+    _T_1255.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire stage_outputs_1_1 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 120:78]
+    stage_outputs_1_1 is invalid @[FFT.scala 120:78]
+    wire _T_1275 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1275 is invalid @[DspReal.scala 165:19]
+    _T_1275.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_1282 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1282 is invalid @[DspReal.scala 165:19]
+    _T_1282.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire stage_outputs_1_2 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 120:78]
+    stage_outputs_1_2 is invalid @[FFT.scala 120:78]
+    wire _T_1302 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1302 is invalid @[DspReal.scala 165:19]
+    _T_1302.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_1309 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1309 is invalid @[DspReal.scala 165:19]
+    _T_1309.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire stage_outputs_1_3 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 120:78]
+    stage_outputs_1_3 is invalid @[FFT.scala 120:78]
+    wire _T_1329 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1329 is invalid @[DspReal.scala 165:19]
+    _T_1329.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_1336 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1336 is invalid @[DspReal.scala 165:19]
+    _T_1336.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire stage_outputs_1_4 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 120:78]
+    stage_outputs_1_4 is invalid @[FFT.scala 120:78]
+    wire _T_1356 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1356 is invalid @[DspReal.scala 165:19]
+    _T_1356.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_1363 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1363 is invalid @[DspReal.scala 165:19]
+    _T_1363.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire stage_outputs_1_5 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 120:78]
+    stage_outputs_1_5 is invalid @[FFT.scala 120:78]
+    wire _T_1383 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1383 is invalid @[DspReal.scala 165:19]
+    _T_1383.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_1390 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1390 is invalid @[DspReal.scala 165:19]
+    _T_1390.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire stage_outputs_1_6 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 120:78]
+    stage_outputs_1_6 is invalid @[FFT.scala 120:78]
+    wire _T_1410 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1410 is invalid @[DspReal.scala 165:19]
+    _T_1410.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_1417 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1417 is invalid @[DspReal.scala 165:19]
+    _T_1417.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire stage_outputs_1_7 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 120:78]
+    stage_outputs_1_7 is invalid @[FFT.scala 120:78]
+    wire _T_1437 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1437 is invalid @[DspReal.scala 165:19]
+    _T_1437.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_1444 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1444 is invalid @[DspReal.scala 165:19]
+    _T_1444.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire stage_outputs_2_0 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 120:78]
+    stage_outputs_2_0 is invalid @[FFT.scala 120:78]
+    wire _T_1464 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1464 is invalid @[DspReal.scala 165:19]
+    _T_1464.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_1471 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1471 is invalid @[DspReal.scala 165:19]
+    _T_1471.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire stage_outputs_2_1 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 120:78]
+    stage_outputs_2_1 is invalid @[FFT.scala 120:78]
+    wire _T_1491 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1491 is invalid @[DspReal.scala 165:19]
+    _T_1491.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_1498 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1498 is invalid @[DspReal.scala 165:19]
+    _T_1498.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire stage_outputs_2_2 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 120:78]
+    stage_outputs_2_2 is invalid @[FFT.scala 120:78]
+    wire _T_1518 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1518 is invalid @[DspReal.scala 165:19]
+    _T_1518.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_1525 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1525 is invalid @[DspReal.scala 165:19]
+    _T_1525.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire stage_outputs_2_3 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 120:78]
+    stage_outputs_2_3 is invalid @[FFT.scala 120:78]
+    wire _T_1545 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1545 is invalid @[DspReal.scala 165:19]
+    _T_1545.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_1552 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1552 is invalid @[DspReal.scala 165:19]
+    _T_1552.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire stage_outputs_2_4 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 120:78]
+    stage_outputs_2_4 is invalid @[FFT.scala 120:78]
+    wire _T_1572 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1572 is invalid @[DspReal.scala 165:19]
+    _T_1572.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_1579 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1579 is invalid @[DspReal.scala 165:19]
+    _T_1579.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire stage_outputs_2_5 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 120:78]
+    stage_outputs_2_5 is invalid @[FFT.scala 120:78]
+    wire _T_1599 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1599 is invalid @[DspReal.scala 165:19]
+    _T_1599.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_1606 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1606 is invalid @[DspReal.scala 165:19]
+    _T_1606.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire stage_outputs_2_6 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 120:78]
+    stage_outputs_2_6 is invalid @[FFT.scala 120:78]
+    wire _T_1626 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1626 is invalid @[DspReal.scala 165:19]
+    _T_1626.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_1633 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1633 is invalid @[DspReal.scala 165:19]
+    _T_1633.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire stage_outputs_2_7 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[FFT.scala 120:78]
+    stage_outputs_2_7 is invalid @[FFT.scala 120:78]
+    stage_outputs_0_0.imaginary.node <= io.in.bits[0].imaginary.node @[FFT.scala 121:67]
+    stage_outputs_0_0.real.node <= io.in.bits[0].real.node @[FFT.scala 121:67]
+    stage_outputs_0_1.imaginary.node <= io.in.bits[1].imaginary.node @[FFT.scala 121:67]
+    stage_outputs_0_1.real.node <= io.in.bits[1].real.node @[FFT.scala 121:67]
+    stage_outputs_0_2.imaginary.node <= io.in.bits[2].imaginary.node @[FFT.scala 121:67]
+    stage_outputs_0_2.real.node <= io.in.bits[2].real.node @[FFT.scala 121:67]
+    stage_outputs_0_3.imaginary.node <= io.in.bits[3].imaginary.node @[FFT.scala 121:67]
+    stage_outputs_0_3.real.node <= io.in.bits[3].real.node @[FFT.scala 121:67]
+    stage_outputs_0_4.imaginary.node <= io.in.bits[4].imaginary.node @[FFT.scala 121:67]
+    stage_outputs_0_4.real.node <= io.in.bits[4].real.node @[FFT.scala 121:67]
+    stage_outputs_0_5.imaginary.node <= io.in.bits[5].imaginary.node @[FFT.scala 121:67]
+    stage_outputs_0_5.real.node <= io.in.bits[5].real.node @[FFT.scala 121:67]
+    stage_outputs_0_6.imaginary.node <= io.in.bits[6].imaginary.node @[FFT.scala 121:67]
+    stage_outputs_0_6.real.node <= io.in.bits[6].real.node @[FFT.scala 121:67]
+    stage_outputs_0_7.imaginary.node <= io.in.bits[7].imaginary.node @[FFT.scala 121:67]
+    stage_outputs_0_7.real.node <= io.in.bits[7].real.node @[FFT.scala 121:67]
+    cmem _T_1664 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[1] @[FFTUtilities.scala 169:21]
+    when io.in.valid : @[Counter.scala 59:17]
+      skip @[Counter.scala 59:17]
+    node _T_1667 = and(io.in.valid, UInt<1>("h01")) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_1675 = _T_1664[UInt<1>("h00")], clock
+      _T_1675.imaginary.node <= stage_outputs_0_1.imaginary.node @[FFTUtilities.scala 172:29]
+      _T_1675.real.node <= stage_outputs_0_1.real.node @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_1683 = _T_1664[UInt<1>("h00")], clock
+    wire _T_1725 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[2] @[FFT.scala 132:38]
+    _T_1725 is invalid @[FFT.scala 132:38]
+    _T_1725[0].imaginary.node <= stage_outputs_0_0.imaginary.node @[FFT.scala 132:38]
+    _T_1725[0].real.node <= stage_outputs_0_0.real.node @[FFT.scala 132:38]
+    _T_1725[1].imaginary.node <= _T_1683.imaginary.node @[FFT.scala 132:38]
+    _T_1725[1].real.node <= _T_1683.real.node @[FFT.scala 132:38]
+    node _T_1766 = bits(sync_0, 0, 0) @[FFT.scala 132:167]
+    wire _T_1768 : UInt<1> @[FFTUtilities.scala 88:21]
+    _T_1768 is invalid @[FFTUtilities.scala 88:21]
+    node _T_1770 = add(_T_1766, UInt<1>("h00")) @[FFTUtilities.scala 89:20]
+    node _T_1771 = tail(_T_1770, 1) @[FFTUtilities.scala 89:20]
+    _T_1768 <= _T_1771 @[FFTUtilities.scala 89:11]
+    wire _T_1786 : UInt<1> @[FFTUtilities.scala 88:21]
+    _T_1786 is invalid @[FFTUtilities.scala 88:21]
+    node _T_1788 = add(_T_1766, UInt<1>("h01")) @[FFTUtilities.scala 89:20]
+    node _T_1789 = tail(_T_1788, 1) @[FFTUtilities.scala 89:20]
+    _T_1786 <= _T_1789 @[FFTUtilities.scala 89:11]
+    wire _T_1844 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[2] @[FFTUtilities.scala 87:8]
+    _T_1844 is invalid @[FFTUtilities.scala 87:8]
+    _T_1844[0].imaginary.node <= _T_1725[_T_1768].imaginary.node @[FFTUtilities.scala 87:8]
+    _T_1844[0].real.node <= _T_1725[_T_1768].real.node @[FFTUtilities.scala 87:8]
+    _T_1844[1].imaginary.node <= _T_1725[_T_1786].imaginary.node @[FFTUtilities.scala 87:8]
+    _T_1844[1].real.node <= _T_1725[_T_1786].real.node @[FFTUtilities.scala 87:8]
+    cmem _T_1899 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[1] @[FFTUtilities.scala 169:21]
+    when io.in.valid : @[Counter.scala 59:17]
+      skip @[Counter.scala 59:17]
+    node _T_1902 = and(io.in.valid, UInt<1>("h01")) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_1910 = _T_1899[UInt<1>("h00")], clock
+      _T_1910.imaginary.node <= _T_1844[0].imaginary.node @[FFTUtilities.scala 172:29]
+      _T_1910.real.node <= _T_1844[0].real.node @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_1918 = _T_1899[UInt<1>("h00")], clock
+    inst BBFMultiply_48_1 of BBFMultiply_48 @[DspReal.scala 106:36]
+    BBFMultiply_48_1.out is invalid
+    BBFMultiply_48_1.in2 is invalid
+    BBFMultiply_48_1.in1 is invalid
+    BBFMultiply_48_1.in1 <= _T_1844[1].real.node @[DspReal.scala 81:21]
+    BBFMultiply_48_1.in2 <= twiddle[0].real.node @[DspReal.scala 82:21]
+    wire _T_1922 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_1922 is invalid @[DspReal.scala 83:19]
+    _T_1922.node <= BBFMultiply_48_1.out @[DspReal.scala 84:14]
+    inst BBFMultiply_49_1 of BBFMultiply_49 @[DspReal.scala 106:36]
+    BBFMultiply_49_1.out is invalid
+    BBFMultiply_49_1.in2 is invalid
+    BBFMultiply_49_1.in1 is invalid
+    BBFMultiply_49_1.in1 <= _T_1844[1].imaginary.node @[DspReal.scala 81:21]
+    BBFMultiply_49_1.in2 <= twiddle[0].imaginary.node @[DspReal.scala 82:21]
+    wire _T_1928 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_1928 is invalid @[DspReal.scala 83:19]
+    _T_1928.node <= BBFMultiply_49_1.out @[DspReal.scala 84:14]
+    wire _T_1934 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_1934 is invalid @[DspReal.scala 165:19]
+    _T_1934.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    inst BBFSubtract_43_1 of BBFSubtract_43 @[DspReal.scala 102:36]
+    BBFSubtract_43_1.out is invalid
+    BBFSubtract_43_1.in2 is invalid
+    BBFSubtract_43_1.in1 is invalid
+    BBFSubtract_43_1.in1 <= _T_1934.node @[DspReal.scala 81:21]
+    BBFSubtract_43_1.in2 <= _T_1928.node @[DspReal.scala 82:21]
+    wire _T_1941 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_1941 is invalid @[DspReal.scala 83:19]
+    _T_1941.node <= BBFSubtract_43_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_72_1 of BBFAdd_72 @[DspReal.scala 98:36]
+    BBFAdd_72_1.out is invalid
+    BBFAdd_72_1.in2 is invalid
+    BBFAdd_72_1.in1 is invalid
+    BBFAdd_72_1.in1 <= _T_1922.node @[DspReal.scala 81:21]
+    BBFAdd_72_1.in2 <= _T_1941.node @[DspReal.scala 82:21]
+    wire _T_1947 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_1947 is invalid @[DspReal.scala 83:19]
+    _T_1947.node <= BBFAdd_72_1.out @[DspReal.scala 84:14]
+    inst BBFMultiply_50_1 of BBFMultiply_50 @[DspReal.scala 106:36]
+    BBFMultiply_50_1.out is invalid
+    BBFMultiply_50_1.in2 is invalid
+    BBFMultiply_50_1.in1 is invalid
+    BBFMultiply_50_1.in1 <= _T_1844[1].real.node @[DspReal.scala 81:21]
+    BBFMultiply_50_1.in2 <= twiddle[0].imaginary.node @[DspReal.scala 82:21]
+    wire _T_1953 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_1953 is invalid @[DspReal.scala 83:19]
+    _T_1953.node <= BBFMultiply_50_1.out @[DspReal.scala 84:14]
+    inst BBFMultiply_51_1 of BBFMultiply_51 @[DspReal.scala 106:36]
+    BBFMultiply_51_1.out is invalid
+    BBFMultiply_51_1.in2 is invalid
+    BBFMultiply_51_1.in1 is invalid
+    BBFMultiply_51_1.in1 <= _T_1844[1].imaginary.node @[DspReal.scala 81:21]
+    BBFMultiply_51_1.in2 <= twiddle[0].real.node @[DspReal.scala 82:21]
+    wire _T_1959 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_1959 is invalid @[DspReal.scala 83:19]
+    _T_1959.node <= BBFMultiply_51_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_73_1 of BBFAdd_73 @[DspReal.scala 98:36]
+    BBFAdd_73_1.out is invalid
+    BBFAdd_73_1.in2 is invalid
+    BBFAdd_73_1.in1 is invalid
+    BBFAdd_73_1.in1 <= _T_1953.node @[DspReal.scala 81:21]
+    BBFAdd_73_1.in2 <= _T_1959.node @[DspReal.scala 82:21]
+    wire _T_1965 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_1965 is invalid @[DspReal.scala 83:19]
+    _T_1965.node <= BBFAdd_73_1.out @[DspReal.scala 84:14]
+    wire _T_1981 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_1981 is invalid @[DspComplex.scala 14:22]
+    _T_1981.real.node <= _T_1947.node @[DspComplex.scala 15:17]
+    _T_1981.imaginary.node <= _T_1965.node @[DspComplex.scala 16:22]
+    inst BBFAdd_74_1 of BBFAdd_74 @[DspReal.scala 98:36]
+    BBFAdd_74_1.out is invalid
+    BBFAdd_74_1.in2 is invalid
+    BBFAdd_74_1.in1 is invalid
+    BBFAdd_74_1.in1 <= _T_1918.real.node @[DspReal.scala 81:21]
+    BBFAdd_74_1.in2 <= _T_1981.real.node @[DspReal.scala 82:21]
+    wire _T_1985 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_1985 is invalid @[DspReal.scala 83:19]
+    _T_1985.node <= BBFAdd_74_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_75_1 of BBFAdd_75 @[DspReal.scala 98:36]
+    BBFAdd_75_1.out is invalid
+    BBFAdd_75_1.in2 is invalid
+    BBFAdd_75_1.in1 is invalid
+    BBFAdd_75_1.in1 <= _T_1918.imaginary.node @[DspReal.scala 81:21]
+    BBFAdd_75_1.in2 <= _T_1981.imaginary.node @[DspReal.scala 82:21]
+    wire _T_1991 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_1991 is invalid @[DspReal.scala 83:19]
+    _T_1991.node <= BBFAdd_75_1.out @[DspReal.scala 84:14]
+    wire _T_2007 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_2007 is invalid @[DspComplex.scala 14:22]
+    _T_2007.real.node <= _T_1985.node @[DspComplex.scala 15:17]
+    _T_2007.imaginary.node <= _T_1991.node @[DspComplex.scala 16:22]
+    wire _T_2011 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_2011 is invalid @[DspReal.scala 165:19]
+    _T_2011.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    inst BBFSubtract_44_1 of BBFSubtract_44 @[DspReal.scala 102:36]
+    BBFSubtract_44_1.out is invalid
+    BBFSubtract_44_1.in2 is invalid
+    BBFSubtract_44_1.in1 is invalid
+    BBFSubtract_44_1.in1 <= _T_2011.node @[DspReal.scala 81:21]
+    BBFSubtract_44_1.in2 <= _T_1981.real.node @[DspReal.scala 82:21]
+    wire _T_2018 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_2018 is invalid @[DspReal.scala 83:19]
+    _T_2018.node <= BBFSubtract_44_1.out @[DspReal.scala 84:14]
+    wire _T_2024 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_2024 is invalid @[DspReal.scala 165:19]
+    _T_2024.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    inst BBFSubtract_45_1 of BBFSubtract_45 @[DspReal.scala 102:36]
+    BBFSubtract_45_1.out is invalid
+    BBFSubtract_45_1.in2 is invalid
+    BBFSubtract_45_1.in1 is invalid
+    BBFSubtract_45_1.in1 <= _T_2024.node @[DspReal.scala 81:21]
+    BBFSubtract_45_1.in2 <= _T_1981.imaginary.node @[DspReal.scala 82:21]
+    wire _T_2031 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_2031 is invalid @[DspReal.scala 83:19]
+    _T_2031.node <= BBFSubtract_45_1.out @[DspReal.scala 84:14]
+    wire _T_2047 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_2047 is invalid @[DspComplex.scala 14:22]
+    _T_2047.real.node <= _T_2018.node @[DspComplex.scala 15:17]
+    _T_2047.imaginary.node <= _T_2031.node @[DspComplex.scala 16:22]
+    inst BBFAdd_76_1 of BBFAdd_76 @[DspReal.scala 98:36]
+    BBFAdd_76_1.out is invalid
+    BBFAdd_76_1.in2 is invalid
+    BBFAdd_76_1.in1 is invalid
+    BBFAdd_76_1.in1 <= _T_1918.real.node @[DspReal.scala 81:21]
+    BBFAdd_76_1.in2 <= _T_2047.real.node @[DspReal.scala 82:21]
+    wire _T_2051 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_2051 is invalid @[DspReal.scala 83:19]
+    _T_2051.node <= BBFAdd_76_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_77_1 of BBFAdd_77 @[DspReal.scala 98:36]
+    BBFAdd_77_1.out is invalid
+    BBFAdd_77_1.in2 is invalid
+    BBFAdd_77_1.in1 is invalid
+    BBFAdd_77_1.in1 <= _T_1918.imaginary.node @[DspReal.scala 81:21]
+    BBFAdd_77_1.in2 <= _T_2047.imaginary.node @[DspReal.scala 82:21]
+    wire _T_2057 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_2057 is invalid @[DspReal.scala 83:19]
+    _T_2057.node <= BBFAdd_77_1.out @[DspReal.scala 84:14]
+    wire _T_2073 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_2073 is invalid @[DspComplex.scala 14:22]
+    _T_2073.real.node <= _T_2051.node @[DspComplex.scala 15:17]
+    _T_2073.imaginary.node <= _T_2057.node @[DspComplex.scala 16:22]
+    cmem _T_2088 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[1] @[FFTUtilities.scala 169:21]
+    when io.in.valid : @[Counter.scala 59:17]
+      skip @[Counter.scala 59:17]
+    node _T_2091 = and(io.in.valid, UInt<1>("h01")) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_2099 = _T_2088[UInt<1>("h00")], clock
+      _T_2099.imaginary.node <= _T_2007.imaginary.node @[FFTUtilities.scala 172:29]
+      _T_2099.real.node <= _T_2007.real.node @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_2107 = _T_2088[UInt<1>("h00")], clock
+    stage_outputs_1_0.imaginary.node <= _T_2107.imaginary.node @[FFT.scala 136:198]
+    stage_outputs_1_0.real.node <= _T_2107.real.node @[FFT.scala 136:198]
+    cmem _T_2122 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[1] @[FFTUtilities.scala 169:21]
+    when io.in.valid : @[Counter.scala 59:17]
+      skip @[Counter.scala 59:17]
+    node _T_2125 = and(io.in.valid, UInt<1>("h01")) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_2133 = _T_2122[UInt<1>("h00")], clock
+      _T_2133.imaginary.node <= _T_2073.imaginary.node @[FFTUtilities.scala 172:29]
+      _T_2133.real.node <= _T_2073.real.node @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_2141 = _T_2122[UInt<1>("h00")], clock
+    stage_outputs_1_1.imaginary.node <= _T_2141.imaginary.node @[FFT.scala 136:198]
+    stage_outputs_1_1.real.node <= _T_2141.real.node @[FFT.scala 136:198]
+    cmem _T_2156 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[1] @[FFTUtilities.scala 169:21]
+    when io.in.valid : @[Counter.scala 59:17]
+      skip @[Counter.scala 59:17]
+    node _T_2159 = and(io.in.valid, UInt<1>("h01")) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_2167 = _T_2156[UInt<1>("h00")], clock
+      _T_2167.imaginary.node <= stage_outputs_0_3.imaginary.node @[FFTUtilities.scala 172:29]
+      _T_2167.real.node <= stage_outputs_0_3.real.node @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_2175 = _T_2156[UInt<1>("h00")], clock
+    wire _T_2217 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[2] @[FFT.scala 132:38]
+    _T_2217 is invalid @[FFT.scala 132:38]
+    _T_2217[0].imaginary.node <= stage_outputs_0_2.imaginary.node @[FFT.scala 132:38]
+    _T_2217[0].real.node <= stage_outputs_0_2.real.node @[FFT.scala 132:38]
+    _T_2217[1].imaginary.node <= _T_2175.imaginary.node @[FFT.scala 132:38]
+    _T_2217[1].real.node <= _T_2175.real.node @[FFT.scala 132:38]
+    node _T_2258 = bits(sync_0, 0, 0) @[FFT.scala 132:167]
+    wire _T_2260 : UInt<1> @[FFTUtilities.scala 88:21]
+    _T_2260 is invalid @[FFTUtilities.scala 88:21]
+    node _T_2262 = add(_T_2258, UInt<1>("h00")) @[FFTUtilities.scala 89:20]
+    node _T_2263 = tail(_T_2262, 1) @[FFTUtilities.scala 89:20]
+    _T_2260 <= _T_2263 @[FFTUtilities.scala 89:11]
+    wire _T_2278 : UInt<1> @[FFTUtilities.scala 88:21]
+    _T_2278 is invalid @[FFTUtilities.scala 88:21]
+    node _T_2280 = add(_T_2258, UInt<1>("h01")) @[FFTUtilities.scala 89:20]
+    node _T_2281 = tail(_T_2280, 1) @[FFTUtilities.scala 89:20]
+    _T_2278 <= _T_2281 @[FFTUtilities.scala 89:11]
+    wire _T_2336 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[2] @[FFTUtilities.scala 87:8]
+    _T_2336 is invalid @[FFTUtilities.scala 87:8]
+    _T_2336[0].imaginary.node <= _T_2217[_T_2260].imaginary.node @[FFTUtilities.scala 87:8]
+    _T_2336[0].real.node <= _T_2217[_T_2260].real.node @[FFTUtilities.scala 87:8]
+    _T_2336[1].imaginary.node <= _T_2217[_T_2278].imaginary.node @[FFTUtilities.scala 87:8]
+    _T_2336[1].real.node <= _T_2217[_T_2278].real.node @[FFTUtilities.scala 87:8]
+    cmem _T_2391 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[1] @[FFTUtilities.scala 169:21]
+    when io.in.valid : @[Counter.scala 59:17]
+      skip @[Counter.scala 59:17]
+    node _T_2394 = and(io.in.valid, UInt<1>("h01")) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_2402 = _T_2391[UInt<1>("h00")], clock
+      _T_2402.imaginary.node <= _T_2336[0].imaginary.node @[FFTUtilities.scala 172:29]
+      _T_2402.real.node <= _T_2336[0].real.node @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_2410 = _T_2391[UInt<1>("h00")], clock
+    inst BBFMultiply_52_1 of BBFMultiply_52 @[DspReal.scala 106:36]
+    BBFMultiply_52_1.out is invalid
+    BBFMultiply_52_1.in2 is invalid
+    BBFMultiply_52_1.in1 is invalid
+    BBFMultiply_52_1.in1 <= _T_2336[1].real.node @[DspReal.scala 81:21]
+    BBFMultiply_52_1.in2 <= twiddle[0].real.node @[DspReal.scala 82:21]
+    wire _T_2414 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_2414 is invalid @[DspReal.scala 83:19]
+    _T_2414.node <= BBFMultiply_52_1.out @[DspReal.scala 84:14]
+    inst BBFMultiply_53_1 of BBFMultiply_53 @[DspReal.scala 106:36]
+    BBFMultiply_53_1.out is invalid
+    BBFMultiply_53_1.in2 is invalid
+    BBFMultiply_53_1.in1 is invalid
+    BBFMultiply_53_1.in1 <= _T_2336[1].imaginary.node @[DspReal.scala 81:21]
+    BBFMultiply_53_1.in2 <= twiddle[0].imaginary.node @[DspReal.scala 82:21]
+    wire _T_2420 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_2420 is invalid @[DspReal.scala 83:19]
+    _T_2420.node <= BBFMultiply_53_1.out @[DspReal.scala 84:14]
+    wire _T_2426 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_2426 is invalid @[DspReal.scala 165:19]
+    _T_2426.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    inst BBFSubtract_46_1 of BBFSubtract_46 @[DspReal.scala 102:36]
+    BBFSubtract_46_1.out is invalid
+    BBFSubtract_46_1.in2 is invalid
+    BBFSubtract_46_1.in1 is invalid
+    BBFSubtract_46_1.in1 <= _T_2426.node @[DspReal.scala 81:21]
+    BBFSubtract_46_1.in2 <= _T_2420.node @[DspReal.scala 82:21]
+    wire _T_2433 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_2433 is invalid @[DspReal.scala 83:19]
+    _T_2433.node <= BBFSubtract_46_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_78_1 of BBFAdd_78 @[DspReal.scala 98:36]
+    BBFAdd_78_1.out is invalid
+    BBFAdd_78_1.in2 is invalid
+    BBFAdd_78_1.in1 is invalid
+    BBFAdd_78_1.in1 <= _T_2414.node @[DspReal.scala 81:21]
+    BBFAdd_78_1.in2 <= _T_2433.node @[DspReal.scala 82:21]
+    wire _T_2439 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_2439 is invalid @[DspReal.scala 83:19]
+    _T_2439.node <= BBFAdd_78_1.out @[DspReal.scala 84:14]
+    inst BBFMultiply_54_1 of BBFMultiply_54 @[DspReal.scala 106:36]
+    BBFMultiply_54_1.out is invalid
+    BBFMultiply_54_1.in2 is invalid
+    BBFMultiply_54_1.in1 is invalid
+    BBFMultiply_54_1.in1 <= _T_2336[1].real.node @[DspReal.scala 81:21]
+    BBFMultiply_54_1.in2 <= twiddle[0].imaginary.node @[DspReal.scala 82:21]
+    wire _T_2445 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_2445 is invalid @[DspReal.scala 83:19]
+    _T_2445.node <= BBFMultiply_54_1.out @[DspReal.scala 84:14]
+    inst BBFMultiply_55_1 of BBFMultiply_55 @[DspReal.scala 106:36]
+    BBFMultiply_55_1.out is invalid
+    BBFMultiply_55_1.in2 is invalid
+    BBFMultiply_55_1.in1 is invalid
+    BBFMultiply_55_1.in1 <= _T_2336[1].imaginary.node @[DspReal.scala 81:21]
+    BBFMultiply_55_1.in2 <= twiddle[0].real.node @[DspReal.scala 82:21]
+    wire _T_2451 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_2451 is invalid @[DspReal.scala 83:19]
+    _T_2451.node <= BBFMultiply_55_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_79_1 of BBFAdd_79 @[DspReal.scala 98:36]
+    BBFAdd_79_1.out is invalid
+    BBFAdd_79_1.in2 is invalid
+    BBFAdd_79_1.in1 is invalid
+    BBFAdd_79_1.in1 <= _T_2445.node @[DspReal.scala 81:21]
+    BBFAdd_79_1.in2 <= _T_2451.node @[DspReal.scala 82:21]
+    wire _T_2457 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_2457 is invalid @[DspReal.scala 83:19]
+    _T_2457.node <= BBFAdd_79_1.out @[DspReal.scala 84:14]
+    wire _T_2473 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_2473 is invalid @[DspComplex.scala 14:22]
+    _T_2473.real.node <= _T_2439.node @[DspComplex.scala 15:17]
+    _T_2473.imaginary.node <= _T_2457.node @[DspComplex.scala 16:22]
+    inst BBFAdd_80_1 of BBFAdd_80 @[DspReal.scala 98:36]
+    BBFAdd_80_1.out is invalid
+    BBFAdd_80_1.in2 is invalid
+    BBFAdd_80_1.in1 is invalid
+    BBFAdd_80_1.in1 <= _T_2410.real.node @[DspReal.scala 81:21]
+    BBFAdd_80_1.in2 <= _T_2473.real.node @[DspReal.scala 82:21]
+    wire _T_2477 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_2477 is invalid @[DspReal.scala 83:19]
+    _T_2477.node <= BBFAdd_80_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_81_1 of BBFAdd_81 @[DspReal.scala 98:36]
+    BBFAdd_81_1.out is invalid
+    BBFAdd_81_1.in2 is invalid
+    BBFAdd_81_1.in1 is invalid
+    BBFAdd_81_1.in1 <= _T_2410.imaginary.node @[DspReal.scala 81:21]
+    BBFAdd_81_1.in2 <= _T_2473.imaginary.node @[DspReal.scala 82:21]
+    wire _T_2483 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_2483 is invalid @[DspReal.scala 83:19]
+    _T_2483.node <= BBFAdd_81_1.out @[DspReal.scala 84:14]
+    wire _T_2499 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_2499 is invalid @[DspComplex.scala 14:22]
+    _T_2499.real.node <= _T_2477.node @[DspComplex.scala 15:17]
+    _T_2499.imaginary.node <= _T_2483.node @[DspComplex.scala 16:22]
+    wire _T_2503 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_2503 is invalid @[DspReal.scala 165:19]
+    _T_2503.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    inst BBFSubtract_47_1 of BBFSubtract_47 @[DspReal.scala 102:36]
+    BBFSubtract_47_1.out is invalid
+    BBFSubtract_47_1.in2 is invalid
+    BBFSubtract_47_1.in1 is invalid
+    BBFSubtract_47_1.in1 <= _T_2503.node @[DspReal.scala 81:21]
+    BBFSubtract_47_1.in2 <= _T_2473.real.node @[DspReal.scala 82:21]
+    wire _T_2510 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_2510 is invalid @[DspReal.scala 83:19]
+    _T_2510.node <= BBFSubtract_47_1.out @[DspReal.scala 84:14]
+    wire _T_2516 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_2516 is invalid @[DspReal.scala 165:19]
+    _T_2516.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    inst BBFSubtract_48_1 of BBFSubtract_48 @[DspReal.scala 102:36]
+    BBFSubtract_48_1.out is invalid
+    BBFSubtract_48_1.in2 is invalid
+    BBFSubtract_48_1.in1 is invalid
+    BBFSubtract_48_1.in1 <= _T_2516.node @[DspReal.scala 81:21]
+    BBFSubtract_48_1.in2 <= _T_2473.imaginary.node @[DspReal.scala 82:21]
+    wire _T_2523 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_2523 is invalid @[DspReal.scala 83:19]
+    _T_2523.node <= BBFSubtract_48_1.out @[DspReal.scala 84:14]
+    wire _T_2539 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_2539 is invalid @[DspComplex.scala 14:22]
+    _T_2539.real.node <= _T_2510.node @[DspComplex.scala 15:17]
+    _T_2539.imaginary.node <= _T_2523.node @[DspComplex.scala 16:22]
+    inst BBFAdd_82_1 of BBFAdd_82 @[DspReal.scala 98:36]
+    BBFAdd_82_1.out is invalid
+    BBFAdd_82_1.in2 is invalid
+    BBFAdd_82_1.in1 is invalid
+    BBFAdd_82_1.in1 <= _T_2410.real.node @[DspReal.scala 81:21]
+    BBFAdd_82_1.in2 <= _T_2539.real.node @[DspReal.scala 82:21]
+    wire _T_2543 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_2543 is invalid @[DspReal.scala 83:19]
+    _T_2543.node <= BBFAdd_82_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_83_1 of BBFAdd_83 @[DspReal.scala 98:36]
+    BBFAdd_83_1.out is invalid
+    BBFAdd_83_1.in2 is invalid
+    BBFAdd_83_1.in1 is invalid
+    BBFAdd_83_1.in1 <= _T_2410.imaginary.node @[DspReal.scala 81:21]
+    BBFAdd_83_1.in2 <= _T_2539.imaginary.node @[DspReal.scala 82:21]
+    wire _T_2549 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_2549 is invalid @[DspReal.scala 83:19]
+    _T_2549.node <= BBFAdd_83_1.out @[DspReal.scala 84:14]
+    wire _T_2565 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_2565 is invalid @[DspComplex.scala 14:22]
+    _T_2565.real.node <= _T_2543.node @[DspComplex.scala 15:17]
+    _T_2565.imaginary.node <= _T_2549.node @[DspComplex.scala 16:22]
+    cmem _T_2580 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[1] @[FFTUtilities.scala 169:21]
+    when io.in.valid : @[Counter.scala 59:17]
+      skip @[Counter.scala 59:17]
+    node _T_2583 = and(io.in.valid, UInt<1>("h01")) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_2591 = _T_2580[UInt<1>("h00")], clock
+      _T_2591.imaginary.node <= _T_2499.imaginary.node @[FFTUtilities.scala 172:29]
+      _T_2591.real.node <= _T_2499.real.node @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_2599 = _T_2580[UInt<1>("h00")], clock
+    stage_outputs_1_2.imaginary.node <= _T_2599.imaginary.node @[FFT.scala 136:198]
+    stage_outputs_1_2.real.node <= _T_2599.real.node @[FFT.scala 136:198]
+    cmem _T_2614 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[1] @[FFTUtilities.scala 169:21]
+    when io.in.valid : @[Counter.scala 59:17]
+      skip @[Counter.scala 59:17]
+    node _T_2617 = and(io.in.valid, UInt<1>("h01")) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_2625 = _T_2614[UInt<1>("h00")], clock
+      _T_2625.imaginary.node <= _T_2565.imaginary.node @[FFTUtilities.scala 172:29]
+      _T_2625.real.node <= _T_2565.real.node @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_2633 = _T_2614[UInt<1>("h00")], clock
+    stage_outputs_1_3.imaginary.node <= _T_2633.imaginary.node @[FFT.scala 136:198]
+    stage_outputs_1_3.real.node <= _T_2633.real.node @[FFT.scala 136:198]
+    cmem _T_2648 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[1] @[FFTUtilities.scala 169:21]
+    when io.in.valid : @[Counter.scala 59:17]
+      skip @[Counter.scala 59:17]
+    node _T_2651 = and(io.in.valid, UInt<1>("h01")) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_2659 = _T_2648[UInt<1>("h00")], clock
+      _T_2659.imaginary.node <= stage_outputs_0_5.imaginary.node @[FFTUtilities.scala 172:29]
+      _T_2659.real.node <= stage_outputs_0_5.real.node @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_2667 = _T_2648[UInt<1>("h00")], clock
+    wire _T_2709 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[2] @[FFT.scala 132:38]
+    _T_2709 is invalid @[FFT.scala 132:38]
+    _T_2709[0].imaginary.node <= stage_outputs_0_4.imaginary.node @[FFT.scala 132:38]
+    _T_2709[0].real.node <= stage_outputs_0_4.real.node @[FFT.scala 132:38]
+    _T_2709[1].imaginary.node <= _T_2667.imaginary.node @[FFT.scala 132:38]
+    _T_2709[1].real.node <= _T_2667.real.node @[FFT.scala 132:38]
+    node _T_2750 = bits(sync_0, 0, 0) @[FFT.scala 132:167]
+    wire _T_2752 : UInt<1> @[FFTUtilities.scala 88:21]
+    _T_2752 is invalid @[FFTUtilities.scala 88:21]
+    node _T_2754 = add(_T_2750, UInt<1>("h00")) @[FFTUtilities.scala 89:20]
+    node _T_2755 = tail(_T_2754, 1) @[FFTUtilities.scala 89:20]
+    _T_2752 <= _T_2755 @[FFTUtilities.scala 89:11]
+    wire _T_2770 : UInt<1> @[FFTUtilities.scala 88:21]
+    _T_2770 is invalid @[FFTUtilities.scala 88:21]
+    node _T_2772 = add(_T_2750, UInt<1>("h01")) @[FFTUtilities.scala 89:20]
+    node _T_2773 = tail(_T_2772, 1) @[FFTUtilities.scala 89:20]
+    _T_2770 <= _T_2773 @[FFTUtilities.scala 89:11]
+    wire _T_2828 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[2] @[FFTUtilities.scala 87:8]
+    _T_2828 is invalid @[FFTUtilities.scala 87:8]
+    _T_2828[0].imaginary.node <= _T_2709[_T_2752].imaginary.node @[FFTUtilities.scala 87:8]
+    _T_2828[0].real.node <= _T_2709[_T_2752].real.node @[FFTUtilities.scala 87:8]
+    _T_2828[1].imaginary.node <= _T_2709[_T_2770].imaginary.node @[FFTUtilities.scala 87:8]
+    _T_2828[1].real.node <= _T_2709[_T_2770].real.node @[FFTUtilities.scala 87:8]
+    cmem _T_2883 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[1] @[FFTUtilities.scala 169:21]
+    when io.in.valid : @[Counter.scala 59:17]
+      skip @[Counter.scala 59:17]
+    node _T_2886 = and(io.in.valid, UInt<1>("h01")) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_2894 = _T_2883[UInt<1>("h00")], clock
+      _T_2894.imaginary.node <= _T_2828[0].imaginary.node @[FFTUtilities.scala 172:29]
+      _T_2894.real.node <= _T_2828[0].real.node @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_2902 = _T_2883[UInt<1>("h00")], clock
+    inst BBFMultiply_56_1 of BBFMultiply_56 @[DspReal.scala 106:36]
+    BBFMultiply_56_1.out is invalid
+    BBFMultiply_56_1.in2 is invalid
+    BBFMultiply_56_1.in1 is invalid
+    BBFMultiply_56_1.in1 <= _T_2828[1].real.node @[DspReal.scala 81:21]
+    BBFMultiply_56_1.in2 <= twiddle[0].real.node @[DspReal.scala 82:21]
+    wire _T_2906 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_2906 is invalid @[DspReal.scala 83:19]
+    _T_2906.node <= BBFMultiply_56_1.out @[DspReal.scala 84:14]
+    inst BBFMultiply_57_1 of BBFMultiply_57 @[DspReal.scala 106:36]
+    BBFMultiply_57_1.out is invalid
+    BBFMultiply_57_1.in2 is invalid
+    BBFMultiply_57_1.in1 is invalid
+    BBFMultiply_57_1.in1 <= _T_2828[1].imaginary.node @[DspReal.scala 81:21]
+    BBFMultiply_57_1.in2 <= twiddle[0].imaginary.node @[DspReal.scala 82:21]
+    wire _T_2912 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_2912 is invalid @[DspReal.scala 83:19]
+    _T_2912.node <= BBFMultiply_57_1.out @[DspReal.scala 84:14]
+    wire _T_2918 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_2918 is invalid @[DspReal.scala 165:19]
+    _T_2918.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    inst BBFSubtract_49_1 of BBFSubtract_49 @[DspReal.scala 102:36]
+    BBFSubtract_49_1.out is invalid
+    BBFSubtract_49_1.in2 is invalid
+    BBFSubtract_49_1.in1 is invalid
+    BBFSubtract_49_1.in1 <= _T_2918.node @[DspReal.scala 81:21]
+    BBFSubtract_49_1.in2 <= _T_2912.node @[DspReal.scala 82:21]
+    wire _T_2925 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_2925 is invalid @[DspReal.scala 83:19]
+    _T_2925.node <= BBFSubtract_49_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_84_1 of BBFAdd_84 @[DspReal.scala 98:36]
+    BBFAdd_84_1.out is invalid
+    BBFAdd_84_1.in2 is invalid
+    BBFAdd_84_1.in1 is invalid
+    BBFAdd_84_1.in1 <= _T_2906.node @[DspReal.scala 81:21]
+    BBFAdd_84_1.in2 <= _T_2925.node @[DspReal.scala 82:21]
+    wire _T_2931 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_2931 is invalid @[DspReal.scala 83:19]
+    _T_2931.node <= BBFAdd_84_1.out @[DspReal.scala 84:14]
+    inst BBFMultiply_58_1 of BBFMultiply_58 @[DspReal.scala 106:36]
+    BBFMultiply_58_1.out is invalid
+    BBFMultiply_58_1.in2 is invalid
+    BBFMultiply_58_1.in1 is invalid
+    BBFMultiply_58_1.in1 <= _T_2828[1].real.node @[DspReal.scala 81:21]
+    BBFMultiply_58_1.in2 <= twiddle[0].imaginary.node @[DspReal.scala 82:21]
+    wire _T_2937 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_2937 is invalid @[DspReal.scala 83:19]
+    _T_2937.node <= BBFMultiply_58_1.out @[DspReal.scala 84:14]
+    inst BBFMultiply_59_1 of BBFMultiply_59 @[DspReal.scala 106:36]
+    BBFMultiply_59_1.out is invalid
+    BBFMultiply_59_1.in2 is invalid
+    BBFMultiply_59_1.in1 is invalid
+    BBFMultiply_59_1.in1 <= _T_2828[1].imaginary.node @[DspReal.scala 81:21]
+    BBFMultiply_59_1.in2 <= twiddle[0].real.node @[DspReal.scala 82:21]
+    wire _T_2943 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_2943 is invalid @[DspReal.scala 83:19]
+    _T_2943.node <= BBFMultiply_59_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_85_1 of BBFAdd_85 @[DspReal.scala 98:36]
+    BBFAdd_85_1.out is invalid
+    BBFAdd_85_1.in2 is invalid
+    BBFAdd_85_1.in1 is invalid
+    BBFAdd_85_1.in1 <= _T_2937.node @[DspReal.scala 81:21]
+    BBFAdd_85_1.in2 <= _T_2943.node @[DspReal.scala 82:21]
+    wire _T_2949 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_2949 is invalid @[DspReal.scala 83:19]
+    _T_2949.node <= BBFAdd_85_1.out @[DspReal.scala 84:14]
+    wire _T_2965 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_2965 is invalid @[DspComplex.scala 14:22]
+    _T_2965.real.node <= _T_2931.node @[DspComplex.scala 15:17]
+    _T_2965.imaginary.node <= _T_2949.node @[DspComplex.scala 16:22]
+    inst BBFAdd_86_1 of BBFAdd_86 @[DspReal.scala 98:36]
+    BBFAdd_86_1.out is invalid
+    BBFAdd_86_1.in2 is invalid
+    BBFAdd_86_1.in1 is invalid
+    BBFAdd_86_1.in1 <= _T_2902.real.node @[DspReal.scala 81:21]
+    BBFAdd_86_1.in2 <= _T_2965.real.node @[DspReal.scala 82:21]
+    wire _T_2969 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_2969 is invalid @[DspReal.scala 83:19]
+    _T_2969.node <= BBFAdd_86_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_87_1 of BBFAdd_87 @[DspReal.scala 98:36]
+    BBFAdd_87_1.out is invalid
+    BBFAdd_87_1.in2 is invalid
+    BBFAdd_87_1.in1 is invalid
+    BBFAdd_87_1.in1 <= _T_2902.imaginary.node @[DspReal.scala 81:21]
+    BBFAdd_87_1.in2 <= _T_2965.imaginary.node @[DspReal.scala 82:21]
+    wire _T_2975 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_2975 is invalid @[DspReal.scala 83:19]
+    _T_2975.node <= BBFAdd_87_1.out @[DspReal.scala 84:14]
+    wire _T_2991 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_2991 is invalid @[DspComplex.scala 14:22]
+    _T_2991.real.node <= _T_2969.node @[DspComplex.scala 15:17]
+    _T_2991.imaginary.node <= _T_2975.node @[DspComplex.scala 16:22]
+    wire _T_2995 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_2995 is invalid @[DspReal.scala 165:19]
+    _T_2995.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    inst BBFSubtract_50_1 of BBFSubtract_50 @[DspReal.scala 102:36]
+    BBFSubtract_50_1.out is invalid
+    BBFSubtract_50_1.in2 is invalid
+    BBFSubtract_50_1.in1 is invalid
+    BBFSubtract_50_1.in1 <= _T_2995.node @[DspReal.scala 81:21]
+    BBFSubtract_50_1.in2 <= _T_2965.real.node @[DspReal.scala 82:21]
+    wire _T_3002 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3002 is invalid @[DspReal.scala 83:19]
+    _T_3002.node <= BBFSubtract_50_1.out @[DspReal.scala 84:14]
+    wire _T_3008 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_3008 is invalid @[DspReal.scala 165:19]
+    _T_3008.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    inst BBFSubtract_51_1 of BBFSubtract_51 @[DspReal.scala 102:36]
+    BBFSubtract_51_1.out is invalid
+    BBFSubtract_51_1.in2 is invalid
+    BBFSubtract_51_1.in1 is invalid
+    BBFSubtract_51_1.in1 <= _T_3008.node @[DspReal.scala 81:21]
+    BBFSubtract_51_1.in2 <= _T_2965.imaginary.node @[DspReal.scala 82:21]
+    wire _T_3015 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3015 is invalid @[DspReal.scala 83:19]
+    _T_3015.node <= BBFSubtract_51_1.out @[DspReal.scala 84:14]
+    wire _T_3031 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_3031 is invalid @[DspComplex.scala 14:22]
+    _T_3031.real.node <= _T_3002.node @[DspComplex.scala 15:17]
+    _T_3031.imaginary.node <= _T_3015.node @[DspComplex.scala 16:22]
+    inst BBFAdd_88_1 of BBFAdd_88 @[DspReal.scala 98:36]
+    BBFAdd_88_1.out is invalid
+    BBFAdd_88_1.in2 is invalid
+    BBFAdd_88_1.in1 is invalid
+    BBFAdd_88_1.in1 <= _T_2902.real.node @[DspReal.scala 81:21]
+    BBFAdd_88_1.in2 <= _T_3031.real.node @[DspReal.scala 82:21]
+    wire _T_3035 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3035 is invalid @[DspReal.scala 83:19]
+    _T_3035.node <= BBFAdd_88_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_89_1 of BBFAdd_89 @[DspReal.scala 98:36]
+    BBFAdd_89_1.out is invalid
+    BBFAdd_89_1.in2 is invalid
+    BBFAdd_89_1.in1 is invalid
+    BBFAdd_89_1.in1 <= _T_2902.imaginary.node @[DspReal.scala 81:21]
+    BBFAdd_89_1.in2 <= _T_3031.imaginary.node @[DspReal.scala 82:21]
+    wire _T_3041 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3041 is invalid @[DspReal.scala 83:19]
+    _T_3041.node <= BBFAdd_89_1.out @[DspReal.scala 84:14]
+    wire _T_3057 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_3057 is invalid @[DspComplex.scala 14:22]
+    _T_3057.real.node <= _T_3035.node @[DspComplex.scala 15:17]
+    _T_3057.imaginary.node <= _T_3041.node @[DspComplex.scala 16:22]
+    cmem _T_3072 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[1] @[FFTUtilities.scala 169:21]
+    when io.in.valid : @[Counter.scala 59:17]
+      skip @[Counter.scala 59:17]
+    node _T_3075 = and(io.in.valid, UInt<1>("h01")) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_3083 = _T_3072[UInt<1>("h00")], clock
+      _T_3083.imaginary.node <= _T_2991.imaginary.node @[FFTUtilities.scala 172:29]
+      _T_3083.real.node <= _T_2991.real.node @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_3091 = _T_3072[UInt<1>("h00")], clock
+    stage_outputs_1_4.imaginary.node <= _T_3091.imaginary.node @[FFT.scala 136:198]
+    stage_outputs_1_4.real.node <= _T_3091.real.node @[FFT.scala 136:198]
+    cmem _T_3106 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[1] @[FFTUtilities.scala 169:21]
+    when io.in.valid : @[Counter.scala 59:17]
+      skip @[Counter.scala 59:17]
+    node _T_3109 = and(io.in.valid, UInt<1>("h01")) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_3117 = _T_3106[UInt<1>("h00")], clock
+      _T_3117.imaginary.node <= _T_3057.imaginary.node @[FFTUtilities.scala 172:29]
+      _T_3117.real.node <= _T_3057.real.node @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_3125 = _T_3106[UInt<1>("h00")], clock
+    stage_outputs_1_5.imaginary.node <= _T_3125.imaginary.node @[FFT.scala 136:198]
+    stage_outputs_1_5.real.node <= _T_3125.real.node @[FFT.scala 136:198]
+    cmem _T_3140 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[1] @[FFTUtilities.scala 169:21]
+    when io.in.valid : @[Counter.scala 59:17]
+      skip @[Counter.scala 59:17]
+    node _T_3143 = and(io.in.valid, UInt<1>("h01")) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_3151 = _T_3140[UInt<1>("h00")], clock
+      _T_3151.imaginary.node <= stage_outputs_0_7.imaginary.node @[FFTUtilities.scala 172:29]
+      _T_3151.real.node <= stage_outputs_0_7.real.node @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_3159 = _T_3140[UInt<1>("h00")], clock
+    wire _T_3201 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[2] @[FFT.scala 132:38]
+    _T_3201 is invalid @[FFT.scala 132:38]
+    _T_3201[0].imaginary.node <= stage_outputs_0_6.imaginary.node @[FFT.scala 132:38]
+    _T_3201[0].real.node <= stage_outputs_0_6.real.node @[FFT.scala 132:38]
+    _T_3201[1].imaginary.node <= _T_3159.imaginary.node @[FFT.scala 132:38]
+    _T_3201[1].real.node <= _T_3159.real.node @[FFT.scala 132:38]
+    node _T_3242 = bits(sync_0, 0, 0) @[FFT.scala 132:167]
+    wire _T_3244 : UInt<1> @[FFTUtilities.scala 88:21]
+    _T_3244 is invalid @[FFTUtilities.scala 88:21]
+    node _T_3246 = add(_T_3242, UInt<1>("h00")) @[FFTUtilities.scala 89:20]
+    node _T_3247 = tail(_T_3246, 1) @[FFTUtilities.scala 89:20]
+    _T_3244 <= _T_3247 @[FFTUtilities.scala 89:11]
+    wire _T_3262 : UInt<1> @[FFTUtilities.scala 88:21]
+    _T_3262 is invalid @[FFTUtilities.scala 88:21]
+    node _T_3264 = add(_T_3242, UInt<1>("h01")) @[FFTUtilities.scala 89:20]
+    node _T_3265 = tail(_T_3264, 1) @[FFTUtilities.scala 89:20]
+    _T_3262 <= _T_3265 @[FFTUtilities.scala 89:11]
+    wire _T_3320 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[2] @[FFTUtilities.scala 87:8]
+    _T_3320 is invalid @[FFTUtilities.scala 87:8]
+    _T_3320[0].imaginary.node <= _T_3201[_T_3244].imaginary.node @[FFTUtilities.scala 87:8]
+    _T_3320[0].real.node <= _T_3201[_T_3244].real.node @[FFTUtilities.scala 87:8]
+    _T_3320[1].imaginary.node <= _T_3201[_T_3262].imaginary.node @[FFTUtilities.scala 87:8]
+    _T_3320[1].real.node <= _T_3201[_T_3262].real.node @[FFTUtilities.scala 87:8]
+    cmem _T_3375 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[1] @[FFTUtilities.scala 169:21]
+    when io.in.valid : @[Counter.scala 59:17]
+      skip @[Counter.scala 59:17]
+    node _T_3378 = and(io.in.valid, UInt<1>("h01")) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_3386 = _T_3375[UInt<1>("h00")], clock
+      _T_3386.imaginary.node <= _T_3320[0].imaginary.node @[FFTUtilities.scala 172:29]
+      _T_3386.real.node <= _T_3320[0].real.node @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_3394 = _T_3375[UInt<1>("h00")], clock
+    inst BBFMultiply_60_1 of BBFMultiply_60 @[DspReal.scala 106:36]
+    BBFMultiply_60_1.out is invalid
+    BBFMultiply_60_1.in2 is invalid
+    BBFMultiply_60_1.in1 is invalid
+    BBFMultiply_60_1.in1 <= _T_3320[1].real.node @[DspReal.scala 81:21]
+    BBFMultiply_60_1.in2 <= twiddle[0].real.node @[DspReal.scala 82:21]
+    wire _T_3398 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3398 is invalid @[DspReal.scala 83:19]
+    _T_3398.node <= BBFMultiply_60_1.out @[DspReal.scala 84:14]
+    inst BBFMultiply_61_1 of BBFMultiply_61 @[DspReal.scala 106:36]
+    BBFMultiply_61_1.out is invalid
+    BBFMultiply_61_1.in2 is invalid
+    BBFMultiply_61_1.in1 is invalid
+    BBFMultiply_61_1.in1 <= _T_3320[1].imaginary.node @[DspReal.scala 81:21]
+    BBFMultiply_61_1.in2 <= twiddle[0].imaginary.node @[DspReal.scala 82:21]
+    wire _T_3404 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3404 is invalid @[DspReal.scala 83:19]
+    _T_3404.node <= BBFMultiply_61_1.out @[DspReal.scala 84:14]
+    wire _T_3410 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_3410 is invalid @[DspReal.scala 165:19]
+    _T_3410.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    inst BBFSubtract_52_1 of BBFSubtract_52 @[DspReal.scala 102:36]
+    BBFSubtract_52_1.out is invalid
+    BBFSubtract_52_1.in2 is invalid
+    BBFSubtract_52_1.in1 is invalid
+    BBFSubtract_52_1.in1 <= _T_3410.node @[DspReal.scala 81:21]
+    BBFSubtract_52_1.in2 <= _T_3404.node @[DspReal.scala 82:21]
+    wire _T_3417 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3417 is invalid @[DspReal.scala 83:19]
+    _T_3417.node <= BBFSubtract_52_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_90_1 of BBFAdd_90 @[DspReal.scala 98:36]
+    BBFAdd_90_1.out is invalid
+    BBFAdd_90_1.in2 is invalid
+    BBFAdd_90_1.in1 is invalid
+    BBFAdd_90_1.in1 <= _T_3398.node @[DspReal.scala 81:21]
+    BBFAdd_90_1.in2 <= _T_3417.node @[DspReal.scala 82:21]
+    wire _T_3423 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3423 is invalid @[DspReal.scala 83:19]
+    _T_3423.node <= BBFAdd_90_1.out @[DspReal.scala 84:14]
+    inst BBFMultiply_62_1 of BBFMultiply_62 @[DspReal.scala 106:36]
+    BBFMultiply_62_1.out is invalid
+    BBFMultiply_62_1.in2 is invalid
+    BBFMultiply_62_1.in1 is invalid
+    BBFMultiply_62_1.in1 <= _T_3320[1].real.node @[DspReal.scala 81:21]
+    BBFMultiply_62_1.in2 <= twiddle[0].imaginary.node @[DspReal.scala 82:21]
+    wire _T_3429 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3429 is invalid @[DspReal.scala 83:19]
+    _T_3429.node <= BBFMultiply_62_1.out @[DspReal.scala 84:14]
+    inst BBFMultiply_63_1 of BBFMultiply_63 @[DspReal.scala 106:36]
+    BBFMultiply_63_1.out is invalid
+    BBFMultiply_63_1.in2 is invalid
+    BBFMultiply_63_1.in1 is invalid
+    BBFMultiply_63_1.in1 <= _T_3320[1].imaginary.node @[DspReal.scala 81:21]
+    BBFMultiply_63_1.in2 <= twiddle[0].real.node @[DspReal.scala 82:21]
+    wire _T_3435 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3435 is invalid @[DspReal.scala 83:19]
+    _T_3435.node <= BBFMultiply_63_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_91_1 of BBFAdd_91 @[DspReal.scala 98:36]
+    BBFAdd_91_1.out is invalid
+    BBFAdd_91_1.in2 is invalid
+    BBFAdd_91_1.in1 is invalid
+    BBFAdd_91_1.in1 <= _T_3429.node @[DspReal.scala 81:21]
+    BBFAdd_91_1.in2 <= _T_3435.node @[DspReal.scala 82:21]
+    wire _T_3441 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3441 is invalid @[DspReal.scala 83:19]
+    _T_3441.node <= BBFAdd_91_1.out @[DspReal.scala 84:14]
+    wire _T_3457 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_3457 is invalid @[DspComplex.scala 14:22]
+    _T_3457.real.node <= _T_3423.node @[DspComplex.scala 15:17]
+    _T_3457.imaginary.node <= _T_3441.node @[DspComplex.scala 16:22]
+    inst BBFAdd_92_1 of BBFAdd_92 @[DspReal.scala 98:36]
+    BBFAdd_92_1.out is invalid
+    BBFAdd_92_1.in2 is invalid
+    BBFAdd_92_1.in1 is invalid
+    BBFAdd_92_1.in1 <= _T_3394.real.node @[DspReal.scala 81:21]
+    BBFAdd_92_1.in2 <= _T_3457.real.node @[DspReal.scala 82:21]
+    wire _T_3461 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3461 is invalid @[DspReal.scala 83:19]
+    _T_3461.node <= BBFAdd_92_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_93_1 of BBFAdd_93 @[DspReal.scala 98:36]
+    BBFAdd_93_1.out is invalid
+    BBFAdd_93_1.in2 is invalid
+    BBFAdd_93_1.in1 is invalid
+    BBFAdd_93_1.in1 <= _T_3394.imaginary.node @[DspReal.scala 81:21]
+    BBFAdd_93_1.in2 <= _T_3457.imaginary.node @[DspReal.scala 82:21]
+    wire _T_3467 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3467 is invalid @[DspReal.scala 83:19]
+    _T_3467.node <= BBFAdd_93_1.out @[DspReal.scala 84:14]
+    wire _T_3483 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_3483 is invalid @[DspComplex.scala 14:22]
+    _T_3483.real.node <= _T_3461.node @[DspComplex.scala 15:17]
+    _T_3483.imaginary.node <= _T_3467.node @[DspComplex.scala 16:22]
+    wire _T_3487 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_3487 is invalid @[DspReal.scala 165:19]
+    _T_3487.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    inst BBFSubtract_53_1 of BBFSubtract_53 @[DspReal.scala 102:36]
+    BBFSubtract_53_1.out is invalid
+    BBFSubtract_53_1.in2 is invalid
+    BBFSubtract_53_1.in1 is invalid
+    BBFSubtract_53_1.in1 <= _T_3487.node @[DspReal.scala 81:21]
+    BBFSubtract_53_1.in2 <= _T_3457.real.node @[DspReal.scala 82:21]
+    wire _T_3494 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3494 is invalid @[DspReal.scala 83:19]
+    _T_3494.node <= BBFSubtract_53_1.out @[DspReal.scala 84:14]
+    wire _T_3500 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_3500 is invalid @[DspReal.scala 165:19]
+    _T_3500.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    inst BBFSubtract_54_1 of BBFSubtract_54 @[DspReal.scala 102:36]
+    BBFSubtract_54_1.out is invalid
+    BBFSubtract_54_1.in2 is invalid
+    BBFSubtract_54_1.in1 is invalid
+    BBFSubtract_54_1.in1 <= _T_3500.node @[DspReal.scala 81:21]
+    BBFSubtract_54_1.in2 <= _T_3457.imaginary.node @[DspReal.scala 82:21]
+    wire _T_3507 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3507 is invalid @[DspReal.scala 83:19]
+    _T_3507.node <= BBFSubtract_54_1.out @[DspReal.scala 84:14]
+    wire _T_3523 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_3523 is invalid @[DspComplex.scala 14:22]
+    _T_3523.real.node <= _T_3494.node @[DspComplex.scala 15:17]
+    _T_3523.imaginary.node <= _T_3507.node @[DspComplex.scala 16:22]
+    inst BBFAdd_94_1 of BBFAdd_94 @[DspReal.scala 98:36]
+    BBFAdd_94_1.out is invalid
+    BBFAdd_94_1.in2 is invalid
+    BBFAdd_94_1.in1 is invalid
+    BBFAdd_94_1.in1 <= _T_3394.real.node @[DspReal.scala 81:21]
+    BBFAdd_94_1.in2 <= _T_3523.real.node @[DspReal.scala 82:21]
+    wire _T_3527 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3527 is invalid @[DspReal.scala 83:19]
+    _T_3527.node <= BBFAdd_94_1.out @[DspReal.scala 84:14]
+    inst BBFAdd_95_1 of BBFAdd_95 @[DspReal.scala 98:36]
+    BBFAdd_95_1.out is invalid
+    BBFAdd_95_1.in2 is invalid
+    BBFAdd_95_1.in1 is invalid
+    BBFAdd_95_1.in1 <= _T_3394.imaginary.node @[DspReal.scala 81:21]
+    BBFAdd_95_1.in2 <= _T_3523.imaginary.node @[DspReal.scala 82:21]
+    wire _T_3533 : {node : UInt<64>} @[DspReal.scala 83:19]
+    _T_3533 is invalid @[DspReal.scala 83:19]
+    _T_3533.node <= BBFAdd_95_1.out @[DspReal.scala 84:14]
+    wire _T_3549 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}} @[DspComplex.scala 14:22]
+    _T_3549 is invalid @[DspComplex.scala 14:22]
+    _T_3549.real.node <= _T_3527.node @[DspComplex.scala 15:17]
+    _T_3549.imaginary.node <= _T_3533.node @[DspComplex.scala 16:22]
+    cmem _T_3564 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[1] @[FFTUtilities.scala 169:21]
+    when io.in.valid : @[Counter.scala 59:17]
+      skip @[Counter.scala 59:17]
+    node _T_3567 = and(io.in.valid, UInt<1>("h01")) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_3575 = _T_3564[UInt<1>("h00")], clock
+      _T_3575.imaginary.node <= _T_3483.imaginary.node @[FFTUtilities.scala 172:29]
+      _T_3575.real.node <= _T_3483.real.node @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_3583 = _T_3564[UInt<1>("h00")], clock
+    stage_outputs_1_6.imaginary.node <= _T_3583.imaginary.node @[FFT.scala 136:198]
+    stage_outputs_1_6.real.node <= _T_3583.real.node @[FFT.scala 136:198]
+    cmem _T_3598 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[1] @[FFTUtilities.scala 169:21]
+    when io.in.valid : @[Counter.scala 59:17]
+      skip @[Counter.scala 59:17]
+    node _T_3601 = and(io.in.valid, UInt<1>("h01")) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_3609 = _T_3598[UInt<1>("h00")], clock
+      _T_3609.imaginary.node <= _T_3549.imaginary.node @[FFTUtilities.scala 172:29]
+      _T_3609.real.node <= _T_3549.real.node @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_3617 = _T_3598[UInt<1>("h00")], clock
+    stage_outputs_1_7.imaginary.node <= _T_3617.imaginary.node @[FFT.scala 136:198]
+    stage_outputs_1_7.real.node <= _T_3617.real.node @[FFT.scala 136:198]
+    cmem _T_3632 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[1] @[FFTUtilities.scala 169:21]
+    when io.in.valid : @[Counter.scala 59:17]
+      skip @[Counter.scala 59:17]
+    node _T_3635 = and(io.in.valid, UInt<1>("h01")) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_3643 = _T_3632[UInt<1>("h00")], clock
+      _T_3643.imaginary.node <= stage_outputs_1_1.imaginary.node @[FFTUtilities.scala 172:29]
+      _T_3643.real.node <= stage_outputs_1_1.real.node @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_3651 = _T_3632[UInt<1>("h00")], clock
+    wire _T_3693 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[2] @[FFT.scala 132:38]
+    _T_3693 is invalid @[FFT.scala 132:38]
+    _T_3693[0].imaginary.node <= stage_outputs_1_0.imaginary.node @[FFT.scala 132:38]
+    _T_3693[0].real.node <= stage_outputs_1_0.real.node @[FFT.scala 132:38]
+    _T_3693[1].imaginary.node <= _T_3651.imaginary.node @[FFT.scala 132:38]
+    _T_3693[1].real.node <= _T_3651.real.node @[FFT.scala 132:38]
+    node _T_3734 = bits(sync_1, 0, 0) @[FFT.scala 132:167]
+    cmem _T_3737 : UInt<1>[1] @[FFTUtilities.scala 169:21]
+    when io.in.valid : @[Counter.scala 59:17]
+      skip @[Counter.scala 59:17]
+    node _T_3740 = and(io.in.valid, UInt<1>("h01")) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_3742 = _T_3737[UInt<1>("h00")], clock
+      _T_3742 <= _T_3734 @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_3744 = _T_3737[UInt<1>("h00")], clock
+    wire _T_3746 : UInt<1> @[FFTUtilities.scala 88:21]
+    _T_3746 is invalid @[FFTUtilities.scala 88:21]
+    node _T_3748 = add(_T_3744, UInt<1>("h00")) @[FFTUtilities.scala 89:20]
+    node _T_3749 = tail(_T_3748, 1) @[FFTUtilities.scala 89:20]
+    _T_3746 <= _T_3749 @[FFTUtilities.scala 89:11]
+    wire _T_3764 : UInt<1> @[FFTUtilities.scala 88:21]
+    _T_3764 is invalid @[FFTUtilities.scala 88:21]
+    node _T_3766 = add(_T_3744, UInt<1>("h01")) @[FFTUtilities.scala 89:20]
+    node _T_3767 = tail(_T_3766, 1) @[FFTUtilities.scala 89:20]
+    _T_3764 <= _T_3767 @[FFTUtilities.scala 89:11]
+    wire _T_3822 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[2] @[FFTUtilities.scala 87:8]
+    _T_3822 is invalid @[FFTUtilities.scala 87:8]
+    _T_3822[0].imaginary.node <= _T_3693[_T_3746].imaginary.node @[FFTUtilities.scala 87:8]
+    _T_3822[0].real.node <= _T_3693[_T_3746].real.node @[FFTUtilities.scala 87:8]
+    _T_3822[1].imaginary.node <= _T_3693[_T_3764].imaginary.node @[FFTUtilities.scala 87:8]
+    _T_3822[1].real.node <= _T_3693[_T_3764].real.node @[FFTUtilities.scala 87:8]
+    cmem _T_3877 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[1] @[FFTUtilities.scala 169:21]
+    when io.in.valid : @[Counter.scala 59:17]
+      skip @[Counter.scala 59:17]
+    node _T_3880 = and(io.in.valid, UInt<1>("h01")) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_3888 = _T_3877[UInt<1>("h00")], clock
+      _T_3888.imaginary.node <= _T_3822[0].imaginary.node @[FFTUtilities.scala 172:29]
+      _T_3888.real.node <= _T_3822[0].real.node @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_3896 = _T_3877[UInt<1>("h00")], clock
+    stage_outputs_2_0.imaginary.node <= _T_3896.imaginary.node @[FFT.scala 134:175]
+    stage_outputs_2_0.real.node <= _T_3896.real.node @[FFT.scala 134:175]
+    stage_outputs_2_1.imaginary.node <= _T_3822[1].imaginary.node @[FFT.scala 134:175]
+    stage_outputs_2_1.real.node <= _T_3822[1].real.node @[FFT.scala 134:175]
+    cmem _T_3911 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[1] @[FFTUtilities.scala 169:21]
+    when io.in.valid : @[Counter.scala 59:17]
+      skip @[Counter.scala 59:17]
+    node _T_3914 = and(io.in.valid, UInt<1>("h01")) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_3922 = _T_3911[UInt<1>("h00")], clock
+      _T_3922.imaginary.node <= stage_outputs_1_3.imaginary.node @[FFTUtilities.scala 172:29]
+      _T_3922.real.node <= stage_outputs_1_3.real.node @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_3930 = _T_3911[UInt<1>("h00")], clock
+    wire _T_3972 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[2] @[FFT.scala 132:38]
+    _T_3972 is invalid @[FFT.scala 132:38]
+    _T_3972[0].imaginary.node <= stage_outputs_1_2.imaginary.node @[FFT.scala 132:38]
+    _T_3972[0].real.node <= stage_outputs_1_2.real.node @[FFT.scala 132:38]
+    _T_3972[1].imaginary.node <= _T_3930.imaginary.node @[FFT.scala 132:38]
+    _T_3972[1].real.node <= _T_3930.real.node @[FFT.scala 132:38]
+    node _T_4013 = bits(sync_1, 0, 0) @[FFT.scala 132:167]
+    cmem _T_4016 : UInt<1>[1] @[FFTUtilities.scala 169:21]
+    when io.in.valid : @[Counter.scala 59:17]
+      skip @[Counter.scala 59:17]
+    node _T_4019 = and(io.in.valid, UInt<1>("h01")) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_4021 = _T_4016[UInt<1>("h00")], clock
+      _T_4021 <= _T_4013 @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_4023 = _T_4016[UInt<1>("h00")], clock
+    wire _T_4025 : UInt<1> @[FFTUtilities.scala 88:21]
+    _T_4025 is invalid @[FFTUtilities.scala 88:21]
+    node _T_4027 = add(_T_4023, UInt<1>("h00")) @[FFTUtilities.scala 89:20]
+    node _T_4028 = tail(_T_4027, 1) @[FFTUtilities.scala 89:20]
+    _T_4025 <= _T_4028 @[FFTUtilities.scala 89:11]
+    wire _T_4043 : UInt<1> @[FFTUtilities.scala 88:21]
+    _T_4043 is invalid @[FFTUtilities.scala 88:21]
+    node _T_4045 = add(_T_4023, UInt<1>("h01")) @[FFTUtilities.scala 89:20]
+    node _T_4046 = tail(_T_4045, 1) @[FFTUtilities.scala 89:20]
+    _T_4043 <= _T_4046 @[FFTUtilities.scala 89:11]
+    wire _T_4101 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[2] @[FFTUtilities.scala 87:8]
+    _T_4101 is invalid @[FFTUtilities.scala 87:8]
+    _T_4101[0].imaginary.node <= _T_3972[_T_4025].imaginary.node @[FFTUtilities.scala 87:8]
+    _T_4101[0].real.node <= _T_3972[_T_4025].real.node @[FFTUtilities.scala 87:8]
+    _T_4101[1].imaginary.node <= _T_3972[_T_4043].imaginary.node @[FFTUtilities.scala 87:8]
+    _T_4101[1].real.node <= _T_3972[_T_4043].real.node @[FFTUtilities.scala 87:8]
+    cmem _T_4156 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[1] @[FFTUtilities.scala 169:21]
+    when io.in.valid : @[Counter.scala 59:17]
+      skip @[Counter.scala 59:17]
+    node _T_4159 = and(io.in.valid, UInt<1>("h01")) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_4167 = _T_4156[UInt<1>("h00")], clock
+      _T_4167.imaginary.node <= _T_4101[0].imaginary.node @[FFTUtilities.scala 172:29]
+      _T_4167.real.node <= _T_4101[0].real.node @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_4175 = _T_4156[UInt<1>("h00")], clock
+    stage_outputs_2_2.imaginary.node <= _T_4175.imaginary.node @[FFT.scala 134:175]
+    stage_outputs_2_2.real.node <= _T_4175.real.node @[FFT.scala 134:175]
+    stage_outputs_2_3.imaginary.node <= _T_4101[1].imaginary.node @[FFT.scala 134:175]
+    stage_outputs_2_3.real.node <= _T_4101[1].real.node @[FFT.scala 134:175]
+    cmem _T_4190 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[1] @[FFTUtilities.scala 169:21]
+    when io.in.valid : @[Counter.scala 59:17]
+      skip @[Counter.scala 59:17]
+    node _T_4193 = and(io.in.valid, UInt<1>("h01")) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_4201 = _T_4190[UInt<1>("h00")], clock
+      _T_4201.imaginary.node <= stage_outputs_1_5.imaginary.node @[FFTUtilities.scala 172:29]
+      _T_4201.real.node <= stage_outputs_1_5.real.node @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_4209 = _T_4190[UInt<1>("h00")], clock
+    wire _T_4251 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[2] @[FFT.scala 132:38]
+    _T_4251 is invalid @[FFT.scala 132:38]
+    _T_4251[0].imaginary.node <= stage_outputs_1_4.imaginary.node @[FFT.scala 132:38]
+    _T_4251[0].real.node <= stage_outputs_1_4.real.node @[FFT.scala 132:38]
+    _T_4251[1].imaginary.node <= _T_4209.imaginary.node @[FFT.scala 132:38]
+    _T_4251[1].real.node <= _T_4209.real.node @[FFT.scala 132:38]
+    node _T_4292 = bits(sync_1, 0, 0) @[FFT.scala 132:167]
+    cmem _T_4295 : UInt<1>[1] @[FFTUtilities.scala 169:21]
+    when io.in.valid : @[Counter.scala 59:17]
+      skip @[Counter.scala 59:17]
+    node _T_4298 = and(io.in.valid, UInt<1>("h01")) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_4300 = _T_4295[UInt<1>("h00")], clock
+      _T_4300 <= _T_4292 @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_4302 = _T_4295[UInt<1>("h00")], clock
+    wire _T_4304 : UInt<1> @[FFTUtilities.scala 88:21]
+    _T_4304 is invalid @[FFTUtilities.scala 88:21]
+    node _T_4306 = add(_T_4302, UInt<1>("h00")) @[FFTUtilities.scala 89:20]
+    node _T_4307 = tail(_T_4306, 1) @[FFTUtilities.scala 89:20]
+    _T_4304 <= _T_4307 @[FFTUtilities.scala 89:11]
+    wire _T_4322 : UInt<1> @[FFTUtilities.scala 88:21]
+    _T_4322 is invalid @[FFTUtilities.scala 88:21]
+    node _T_4324 = add(_T_4302, UInt<1>("h01")) @[FFTUtilities.scala 89:20]
+    node _T_4325 = tail(_T_4324, 1) @[FFTUtilities.scala 89:20]
+    _T_4322 <= _T_4325 @[FFTUtilities.scala 89:11]
+    wire _T_4380 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[2] @[FFTUtilities.scala 87:8]
+    _T_4380 is invalid @[FFTUtilities.scala 87:8]
+    _T_4380[0].imaginary.node <= _T_4251[_T_4304].imaginary.node @[FFTUtilities.scala 87:8]
+    _T_4380[0].real.node <= _T_4251[_T_4304].real.node @[FFTUtilities.scala 87:8]
+    _T_4380[1].imaginary.node <= _T_4251[_T_4322].imaginary.node @[FFTUtilities.scala 87:8]
+    _T_4380[1].real.node <= _T_4251[_T_4322].real.node @[FFTUtilities.scala 87:8]
+    cmem _T_4435 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[1] @[FFTUtilities.scala 169:21]
+    when io.in.valid : @[Counter.scala 59:17]
+      skip @[Counter.scala 59:17]
+    node _T_4438 = and(io.in.valid, UInt<1>("h01")) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_4446 = _T_4435[UInt<1>("h00")], clock
+      _T_4446.imaginary.node <= _T_4380[0].imaginary.node @[FFTUtilities.scala 172:29]
+      _T_4446.real.node <= _T_4380[0].real.node @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_4454 = _T_4435[UInt<1>("h00")], clock
+    stage_outputs_2_4.imaginary.node <= _T_4454.imaginary.node @[FFT.scala 134:175]
+    stage_outputs_2_4.real.node <= _T_4454.real.node @[FFT.scala 134:175]
+    stage_outputs_2_5.imaginary.node <= _T_4380[1].imaginary.node @[FFT.scala 134:175]
+    stage_outputs_2_5.real.node <= _T_4380[1].real.node @[FFT.scala 134:175]
+    cmem _T_4469 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[1] @[FFTUtilities.scala 169:21]
+    when io.in.valid : @[Counter.scala 59:17]
+      skip @[Counter.scala 59:17]
+    node _T_4472 = and(io.in.valid, UInt<1>("h01")) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_4480 = _T_4469[UInt<1>("h00")], clock
+      _T_4480.imaginary.node <= stage_outputs_1_7.imaginary.node @[FFTUtilities.scala 172:29]
+      _T_4480.real.node <= stage_outputs_1_7.real.node @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_4488 = _T_4469[UInt<1>("h00")], clock
+    wire _T_4530 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[2] @[FFT.scala 132:38]
+    _T_4530 is invalid @[FFT.scala 132:38]
+    _T_4530[0].imaginary.node <= stage_outputs_1_6.imaginary.node @[FFT.scala 132:38]
+    _T_4530[0].real.node <= stage_outputs_1_6.real.node @[FFT.scala 132:38]
+    _T_4530[1].imaginary.node <= _T_4488.imaginary.node @[FFT.scala 132:38]
+    _T_4530[1].real.node <= _T_4488.real.node @[FFT.scala 132:38]
+    node _T_4571 = bits(sync_1, 0, 0) @[FFT.scala 132:167]
+    cmem _T_4574 : UInt<1>[1] @[FFTUtilities.scala 169:21]
+    when io.in.valid : @[Counter.scala 59:17]
+      skip @[Counter.scala 59:17]
+    node _T_4577 = and(io.in.valid, UInt<1>("h01")) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_4579 = _T_4574[UInt<1>("h00")], clock
+      _T_4579 <= _T_4571 @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_4581 = _T_4574[UInt<1>("h00")], clock
+    wire _T_4583 : UInt<1> @[FFTUtilities.scala 88:21]
+    _T_4583 is invalid @[FFTUtilities.scala 88:21]
+    node _T_4585 = add(_T_4581, UInt<1>("h00")) @[FFTUtilities.scala 89:20]
+    node _T_4586 = tail(_T_4585, 1) @[FFTUtilities.scala 89:20]
+    _T_4583 <= _T_4586 @[FFTUtilities.scala 89:11]
+    wire _T_4601 : UInt<1> @[FFTUtilities.scala 88:21]
+    _T_4601 is invalid @[FFTUtilities.scala 88:21]
+    node _T_4603 = add(_T_4581, UInt<1>("h01")) @[FFTUtilities.scala 89:20]
+    node _T_4604 = tail(_T_4603, 1) @[FFTUtilities.scala 89:20]
+    _T_4601 <= _T_4604 @[FFTUtilities.scala 89:11]
+    wire _T_4659 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[2] @[FFTUtilities.scala 87:8]
+    _T_4659 is invalid @[FFTUtilities.scala 87:8]
+    _T_4659[0].imaginary.node <= _T_4530[_T_4583].imaginary.node @[FFTUtilities.scala 87:8]
+    _T_4659[0].real.node <= _T_4530[_T_4583].real.node @[FFTUtilities.scala 87:8]
+    _T_4659[1].imaginary.node <= _T_4530[_T_4601].imaginary.node @[FFTUtilities.scala 87:8]
+    _T_4659[1].real.node <= _T_4530[_T_4601].real.node @[FFTUtilities.scala 87:8]
+    cmem _T_4714 : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[1] @[FFTUtilities.scala 169:21]
+    when io.in.valid : @[Counter.scala 59:17]
+      skip @[Counter.scala 59:17]
+    node _T_4717 = and(io.in.valid, UInt<1>("h01")) @[Counter.scala 60:20]
+    when io.in.valid : @[FFTUtilities.scala 171:17]
+      infer mport _T_4725 = _T_4714[UInt<1>("h00")], clock
+      _T_4725.imaginary.node <= _T_4659[0].imaginary.node @[FFTUtilities.scala 172:29]
+      _T_4725.real.node <= _T_4659[0].real.node @[FFTUtilities.scala 172:29]
+      skip @[FFTUtilities.scala 171:17]
+    infer mport _T_4733 = _T_4714[UInt<1>("h00")], clock
+    stage_outputs_2_6.imaginary.node <= _T_4733.imaginary.node @[FFT.scala 134:175]
+    stage_outputs_2_6.real.node <= _T_4733.real.node @[FFT.scala 134:175]
+    stage_outputs_2_7.imaginary.node <= _T_4659[1].imaginary.node @[FFT.scala 134:175]
+    stage_outputs_2_7.real.node <= _T_4659[1].real.node @[FFT.scala 134:175]
+    io.out.bits[0].imaginary.node <= stage_outputs_2_0.imaginary.node @[FFT.scala 143:15]
+    io.out.bits[0].real.node <= stage_outputs_2_0.real.node @[FFT.scala 143:15]
+    io.out.bits[1].imaginary.node <= stage_outputs_2_1.imaginary.node @[FFT.scala 143:15]
+    io.out.bits[1].real.node <= stage_outputs_2_1.real.node @[FFT.scala 143:15]
+    io.out.bits[2].imaginary.node <= stage_outputs_2_2.imaginary.node @[FFT.scala 143:15]
+    io.out.bits[2].real.node <= stage_outputs_2_2.real.node @[FFT.scala 143:15]
+    io.out.bits[3].imaginary.node <= stage_outputs_2_3.imaginary.node @[FFT.scala 143:15]
+    io.out.bits[3].real.node <= stage_outputs_2_3.real.node @[FFT.scala 143:15]
+    io.out.bits[4].imaginary.node <= stage_outputs_2_4.imaginary.node @[FFT.scala 143:15]
+    io.out.bits[4].real.node <= stage_outputs_2_4.real.node @[FFT.scala 143:15]
+    io.out.bits[5].imaginary.node <= stage_outputs_2_5.imaginary.node @[FFT.scala 143:15]
+    io.out.bits[5].real.node <= stage_outputs_2_5.real.node @[FFT.scala 143:15]
+    io.out.bits[6].imaginary.node <= stage_outputs_2_6.imaginary.node @[FFT.scala 143:15]
+    io.out.bits[6].real.node <= stage_outputs_2_6.real.node @[FFT.scala 143:15]
+    io.out.bits[7].imaginary.node <= stage_outputs_2_7.imaginary.node @[FFT.scala 143:15]
+    io.out.bits[7].real.node <= stage_outputs_2_7.real.node @[FFT.scala 143:15]
+    
+  module FFTUnpacked : 
+    input clock : Clock
+    input reset : UInt<1>
+    output io : {flip in : {valid : UInt<1>, bits : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[8], sync : UInt<1>}, out : {valid : UInt<1>, bits : {real : {node : UInt<64>}, imaginary : {node : UInt<64>}}[8], sync : UInt<1>}}
+    
+    io is invalid
+    io is invalid
+    wire _T_5 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_5 is invalid @[DspReal.scala 165:19]
+    _T_5.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_12 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_12 is invalid @[DspReal.scala 165:19]
+    _T_12.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_316 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_316 is invalid @[DspReal.scala 165:19]
+    _T_316.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    wire _T_323 : {node : UInt<64>} @[DspReal.scala 165:19]
+    _T_323 is invalid @[DspReal.scala 165:19]
+    _T_323.node <= UInt<64>("h00") @[DspReal.scala 166:14]
+    inst direct of DirectFFT @[FFT.scala 155:22]
+    direct.io is invalid
+    direct.clock <= clock
+    direct.reset <= reset
+    io.out.sync <= direct.io.out.sync @[FFT.scala 156:10]
+    io.out.bits[0].imaginary.node <= direct.io.out.bits[0].imaginary.node @[FFT.scala 156:10]
+    io.out.bits[0].real.node <= direct.io.out.bits[0].real.node @[FFT.scala 156:10]
+    io.out.bits[1].imaginary.node <= direct.io.out.bits[1].imaginary.node @[FFT.scala 156:10]
+    io.out.bits[1].real.node <= direct.io.out.bits[1].real.node @[FFT.scala 156:10]
+    io.out.bits[2].imaginary.node <= direct.io.out.bits[2].imaginary.node @[FFT.scala 156:10]
+    io.out.bits[2].real.node <= direct.io.out.bits[2].real.node @[FFT.scala 156:10]
+    io.out.bits[3].imaginary.node <= direct.io.out.bits[3].imaginary.node @[FFT.scala 156:10]
+    io.out.bits[3].real.node <= direct.io.out.bits[3].real.node @[FFT.scala 156:10]
+    io.out.bits[4].imaginary.node <= direct.io.out.bits[4].imaginary.node @[FFT.scala 156:10]
+    io.out.bits[4].real.node <= direct.io.out.bits[4].real.node @[FFT.scala 156:10]
+    io.out.bits[5].imaginary.node <= direct.io.out.bits[5].imaginary.node @[FFT.scala 156:10]
+    io.out.bits[5].real.node <= direct.io.out.bits[5].real.node @[FFT.scala 156:10]
+    io.out.bits[6].imaginary.node <= direct.io.out.bits[6].imaginary.node @[FFT.scala 156:10]
+    io.out.bits[6].real.node <= direct.io.out.bits[6].real.node @[FFT.scala 156:10]
+    io.out.bits[7].imaginary.node <= direct.io.out.bits[7].imaginary.node @[FFT.scala 156:10]
+    io.out.bits[7].real.node <= direct.io.out.bits[7].real.node @[FFT.scala 156:10]
+    io.out.valid <= direct.io.out.valid @[FFT.scala 156:10]
+    inst BiplexFFT_1 of BiplexFFT @[FFT.scala 159:24]
+    BiplexFFT_1.io is invalid
+    BiplexFFT_1.clock <= clock
+    BiplexFFT_1.reset <= reset
+    direct.io.in.sync <= BiplexFFT_1.io.out.sync @[FFT.scala 160:18]
+    direct.io.in.bits[0].imaginary.node <= BiplexFFT_1.io.out.bits[0].imaginary.node @[FFT.scala 160:18]
+    direct.io.in.bits[0].real.node <= BiplexFFT_1.io.out.bits[0].real.node @[FFT.scala 160:18]
+    direct.io.in.bits[1].imaginary.node <= BiplexFFT_1.io.out.bits[1].imaginary.node @[FFT.scala 160:18]
+    direct.io.in.bits[1].real.node <= BiplexFFT_1.io.out.bits[1].real.node @[FFT.scala 160:18]
+    direct.io.in.bits[2].imaginary.node <= BiplexFFT_1.io.out.bits[2].imaginary.node @[FFT.scala 160:18]
+    direct.io.in.bits[2].real.node <= BiplexFFT_1.io.out.bits[2].real.node @[FFT.scala 160:18]
+    direct.io.in.bits[3].imaginary.node <= BiplexFFT_1.io.out.bits[3].imaginary.node @[FFT.scala 160:18]
+    direct.io.in.bits[3].real.node <= BiplexFFT_1.io.out.bits[3].real.node @[FFT.scala 160:18]
+    direct.io.in.bits[4].imaginary.node <= BiplexFFT_1.io.out.bits[4].imaginary.node @[FFT.scala 160:18]
+    direct.io.in.bits[4].real.node <= BiplexFFT_1.io.out.bits[4].real.node @[FFT.scala 160:18]
+    direct.io.in.bits[5].imaginary.node <= BiplexFFT_1.io.out.bits[5].imaginary.node @[FFT.scala 160:18]
+    direct.io.in.bits[5].real.node <= BiplexFFT_1.io.out.bits[5].real.node @[FFT.scala 160:18]
+    direct.io.in.bits[6].imaginary.node <= BiplexFFT_1.io.out.bits[6].imaginary.node @[FFT.scala 160:18]
+    direct.io.in.bits[6].real.node <= BiplexFFT_1.io.out.bits[6].real.node @[FFT.scala 160:18]
+    direct.io.in.bits[7].imaginary.node <= BiplexFFT_1.io.out.bits[7].imaginary.node @[FFT.scala 160:18]
+    direct.io.in.bits[7].real.node <= BiplexFFT_1.io.out.bits[7].real.node @[FFT.scala 160:18]
+    direct.io.in.valid <= BiplexFFT_1.io.out.valid @[FFT.scala 160:18]
+    BiplexFFT_1.io.in.sync <= io.in.sync @[FFT.scala 161:18]
+    BiplexFFT_1.io.in.bits[0].imaginary.node <= io.in.bits[0].imaginary.node @[FFT.scala 161:18]
+    BiplexFFT_1.io.in.bits[0].real.node <= io.in.bits[0].real.node @[FFT.scala 161:18]
+    BiplexFFT_1.io.in.bits[1].imaginary.node <= io.in.bits[1].imaginary.node @[FFT.scala 161:18]
+    BiplexFFT_1.io.in.bits[1].real.node <= io.in.bits[1].real.node @[FFT.scala 161:18]
+    BiplexFFT_1.io.in.bits[2].imaginary.node <= io.in.bits[2].imaginary.node @[FFT.scala 161:18]
+    BiplexFFT_1.io.in.bits[2].real.node <= io.in.bits[2].real.node @[FFT.scala 161:18]
+    BiplexFFT_1.io.in.bits[3].imaginary.node <= io.in.bits[3].imaginary.node @[FFT.scala 161:18]
+    BiplexFFT_1.io.in.bits[3].real.node <= io.in.bits[3].real.node @[FFT.scala 161:18]
+    BiplexFFT_1.io.in.bits[4].imaginary.node <= io.in.bits[4].imaginary.node @[FFT.scala 161:18]
+    BiplexFFT_1.io.in.bits[4].real.node <= io.in.bits[4].real.node @[FFT.scala 161:18]
+    BiplexFFT_1.io.in.bits[5].imaginary.node <= io.in.bits[5].imaginary.node @[FFT.scala 161:18]
+    BiplexFFT_1.io.in.bits[5].real.node <= io.in.bits[5].real.node @[FFT.scala 161:18]
+    BiplexFFT_1.io.in.bits[6].imaginary.node <= io.in.bits[6].imaginary.node @[FFT.scala 161:18]
+    BiplexFFT_1.io.in.bits[6].real.node <= io.in.bits[6].real.node @[FFT.scala 161:18]
+    BiplexFFT_1.io.in.bits[7].imaginary.node <= io.in.bits[7].imaginary.node @[FFT.scala 161:18]
+    BiplexFFT_1.io.in.bits[7].real.node <= io.in.bits[7].real.node @[FFT.scala 161:18]
+    BiplexFFT_1.io.in.valid <= io.in.valid @[FFT.scala 161:18]
+    

--- a/src/test/resources/fft.script
+++ b/src/test/resources/fft.script
@@ -1,0 +1,7 @@
+
+record-vcd src/test/resources/fft.vcd
+reset 10
+randomize
+step 10
+record-vcd done
+quit

--- a/src/test/resources/fft.script
+++ b/src/test/resources/fft.script
@@ -2,6 +2,42 @@
 record-vcd src/test/resources/fft.vcd
 reset 10
 randomize
-step 10
+step 1
+randomize
+step 1
+randomize
+step 1
+randomize
+step 1
+randomize
+step 1
+randomize
+step 1
+randomize
+step 1
+randomize
+step 1
+randomize
+step 1
+randomize
+step 1
+randomize
+step 1
+randomize
+step 1
+randomize
+step 1
+randomize
+step 1
+randomize
+step 1
+randomize
+step 1
+randomize
+step 1
+randomize
+step 1
+randomize
+step 1
 record-vcd done
 quit


### PR DESCRIPTION
Add wires to scopes when they are first encountered
Update a mythical clock signal as interpreter cycles
Add scopes from wires as they are encountered
Add instance name tracking to dependency graph
Removed requirement that repl only allows vcd output if script is loaded
repl now shows null pointer exceptions without dying
Add fft firrtl file to resources