### PR TITLE
Ignore lib (for rocket build)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -253,3 +253,5 @@ hs_err_pid*
 
 /src/main/scala/firrtl_interpreter/playground.sc
 /*.firrtl_interpreter.vcd
+
+/lib


### PR DESCRIPTION
It's helpful for me if git ignores /lib added by dsp-framework and/or craft2-chip
