### PR TITLE
Another round of VCD recording enhancments

### DIFF
--- a/src/main/scala/firrtl_interpreter/DependencyGraph.scala
+++ b/src/main/scala/firrtl_interpreter/DependencyGraph.scala
@@ -115,7 +115,7 @@ object DependencyGraph extends SimpleLogger {
         dependencyGraph.registerNames += expandedName
         dependencyGraph.recordName(expandedName)
         dependencyGraph.recordType(expandedName, tpe)
-        dependencyGraph.registers += renamedDefRegister
+        dependencyGraph.registers(expandedName) = renamedDefRegister
         dependencyGraph.addSourceInfo(expandedName, info)
         s
       case defMemory: DefMemory =>
@@ -270,7 +270,7 @@ class DependencyGraph(val circuit: Circuit,
   val validNames       = new mutable.HashSet[String]
   val nameToType       = new mutable.HashMap[String, Type]
   val registerNames    = new mutable.HashSet[String]
-  val registers        = new ArrayBuffer[DefRegister]
+  val registers        = new mutable.HashMap[String, DefRegister]
   val memories         = new mutable.HashMap[String, Memory]
   val memoryKeys       = new mutable.HashMap[String, Memory]
   val memoryOutputKeys = new mutable.HashMap[String, Seq[String]]

--- a/src/main/scala/firrtl_interpreter/Driver.scala
+++ b/src/main/scala/firrtl_interpreter/Driver.scala
@@ -6,6 +6,7 @@ import firrtl.ExecutionOptionsManager
 
 case class InterpreterOptions(
     writeVCD:          Boolean              = false,
+    vcdShowUnderscored:Boolean              = false,
     setVerbose:        Boolean              = false,
     setOrderedExec:    Boolean              = false,
     allowCycles:       Boolean              = false,
@@ -39,6 +40,13 @@ trait HasInterpreterOptions {
       interpreterOptions = interpreterOptions.copy(writeVCD = true)
     }
     .text("writes vcd execution log, filename will be base on top")
+
+  parser.opt[Unit]("fint-vcd-show-underscored-vars")
+    .abbr("fivsuv")
+    .foreach { _ =>
+      interpreterOptions = interpreterOptions.copy(vcdShowUnderscored = true)
+    }
+    .text("vcd output by default does not show var that start with underscore, this overrides that")
 
   parser.opt[Unit]("fint-verbose")
     .abbr("fiv")

--- a/src/main/scala/firrtl_interpreter/FirrtlRepl.scala
+++ b/src/main/scala/firrtl_interpreter/FirrtlRepl.scala
@@ -320,7 +320,8 @@ class FirrtlRepl(val optionsManager: ExecutionOptionsManager with HasReplConfig 
             case Some("done")   =>
               interpreter.disableVCD()
             case Some(fileName) =>
-              interpreter.makeVCDLogger(fileName)
+              interpreter.makeVCDLogger(
+                fileName, showUnderscored = optionsManager.interpreterOptions.vcdShowUnderscored)
             case _ =>
               interpreter.disableVCD()
           }
@@ -902,7 +903,9 @@ class FirrtlRepl(val optionsManager: ExecutionOptionsManager with HasReplConfig 
       new Command("quit") {
         def usage: (String, String) = ("quit", "exit the interpreter")
         def run(args: Array[String]): Unit = {
-          history.removeLast()
+          if(! history.isEmpty) {
+            history.removeLast()
+          }
           done = true
         }
       }

--- a/src/main/scala/firrtl_interpreter/InterpretiveTester.scala
+++ b/src/main/scala/firrtl_interpreter/InterpretiveTester.scala
@@ -37,7 +37,10 @@ class InterpretiveTester(
   if(interpreterOptions.writeVCD) {
     optionsManager.setTopNameIfNotSet(interpreter.loweredAst.main)
     optionsManager.makeTargetDir()
-    interpreter.makeVCDLogger(interpreterOptions.vcdOutputFileName(optionsManager))
+    interpreter.makeVCDLogger(
+      interpreterOptions.vcdOutputFileName(optionsManager),
+      interpreterOptions.vcdShowUnderscored
+    )
   }
 
   def setVerbose(value: Boolean = true): Unit = {

--- a/src/test/scala/firrtl_interpreter/vcd/VCDSpec.scala
+++ b/src/test/scala/firrtl_interpreter/vcd/VCDSpec.scala
@@ -56,12 +56,12 @@ class VCDSpec extends FlatSpec with Matchers {
       vcd.incrementTime()
     }
 
-    vcd.valuesAtTime(0).size should be (3)
-    vcd.valuesAtTime(1).size should be (1)
-    vcd.valuesAtTime(2).size should be (2)
-    vcd.valuesAtTime(3).size should be (1)
-    vcd.valuesAtTime(4).size should be (3)
-    vcd.valuesAtTime(5).size should be (1)
+    vcd.valuesAtTime(1).size should be (3)
+    vcd.valuesAtTime(2).size should be (1)
+    vcd.valuesAtTime(3).size should be (2)
+    vcd.valuesAtTime(4).size should be (1)
+    vcd.valuesAtTime(5).size should be (3)
+    vcd.valuesAtTime(6).size should be (1)
 
     println(vcd.serialize)
   }


### PR DESCRIPTION
By default do not record variables whose names begin with underscore
TimeStamp in VCD logger starts at 0 now instead of -1
A lot of changes to clock management particularly with respect to vcd output
register inits are now handled during register dependency instead of separately
changes to top level module input are logged as happening on clock negative edge
all other circuit changes should take place on positive edge
Registers are now stored independency graph as map to find them easier
Fix minor bug on empty history