### PR TITLE
BlackBox name fix, pass options better into interpreter

### DIFF
--- a/src/main/scala/firrtl_interpreter/FirrtlTerp.scala
+++ b/src/main/scala/firrtl_interpreter/FirrtlTerp.scala
@@ -27,14 +27,14 @@ class FirrtlTerp(val ast: Circuit, val interpreterOptions: InterpreterOptions) e
   def stopped: Boolean = lastStopResult.nonEmpty
   def stopResult: Int  = lastStopResult.get
 
-  val loweredAst = if(interpreterOptions.lowCompileAtLoad) ToLoFirrtl.lower(ast) else ast
+  val loweredAst: Circuit = if(interpreterOptions.lowCompileAtLoad) ToLoFirrtl.lower(ast) else ast
 
   if(interpreterOptions.showFirrtlAtLoad) {
     println("LoFirrtl" + "=" * 120)
     println(loweredAst.serialize)
   }
 
-  val blackBoxFactories = interpreterOptions.blackBoxFactories
+  val blackBoxFactories: Seq[BlackBoxFactory] = interpreterOptions.blackBoxFactories
 
   /**
     * turns on evaluator debugging. Can make output quite
@@ -72,7 +72,7 @@ class FirrtlTerp(val ast: Circuit, val interpreterOptions: InterpreterOptions) e
     circuitState = circuitState
   )
   evaluator.evaluationStack.maxExecutionDepth = interpreterOptions.maxExecutionDepth
-  val timer = evaluator.timer
+  val timer: Timer = evaluator.timer
 
   setVerbose(interpreterOptions.setVerbose)
 
@@ -133,7 +133,7 @@ class FirrtlTerp(val ast: Circuit, val interpreterOptions: InterpreterOptions) e
         s"Error: setValue($name) not on input, use setValue($name, force=true) to override")
     }
 
-    val concreteValue = makeConcreteValue(name, value, poisoned = false)
+    val concreteValue = makeConcreteValue(name, value)
 
     circuitState.setValue(name, concreteValue, registerPoke = registerPoke)
   }
@@ -152,7 +152,7 @@ class FirrtlTerp(val ast: Circuit, val interpreterOptions: InterpreterOptions) e
   }
 
   def reEvaluate(name: String): Unit = {
-    setVerbose(true)
+    setVerbose()
     evaluateCircuit(Seq(name))
   }
 
@@ -223,11 +223,37 @@ class FirrtlTerp(val ast: Circuit, val interpreterOptions: InterpreterOptions) e
 object FirrtlTerp {
   val blackBoxFactory = new DspRealFactory
 
-  def apply(input: String,
-            verbose: Boolean = false,
-            blackBoxFactories: Seq[BlackBoxFactory] = Seq(blackBoxFactory)): FirrtlTerp = {
+  def apply(input: String, interpreterOptions: InterpreterOptions = InterpreterOptions()): FirrtlTerp = {
     val ast = firrtl.Parser.parse(input.split("\n").toIterator)
-    val options = new InterpreterOptions(blackBoxFactories = blackBoxFactories, setVerbose = verbose)
+    val interpreter = new FirrtlTerp(ast, interpreterOptions)
+
+    /* run the circuit once to get the circuit state fully populated. Evaluate all makes sure both
+    branches of muxes get computed, while we are at we can compute the sort key order
+     */
+    try {
+      val saveUseTopologicalSortedKeys = interpreter.evaluator.useTopologicalSortedKeys
+      val saveEvaluateAll = interpreter.evaluator.evaluateAll
+
+      interpreter.evaluator.evaluateAll = true
+      interpreter.evaluator.useTopologicalSortedKeys = true
+      interpreter.evaluateCircuit()
+
+      interpreter.evaluator.useTopologicalSortedKeys = saveUseTopologicalSortedKeys
+      interpreter.evaluator.evaluateAll = saveEvaluateAll
+    }
+    catch {
+      case ie: InterpreterException =>
+        println(s"Error: InterpreterExecption(${ie.getMessage} during warmup evaluation")
+    }
+    interpreter
+  }
+
+  @deprecated("This loses options passed in from the command line, use other appluy methods", since = "2017-01-12")
+  def apply(input: String,
+            verbose: Boolean,
+            blackBoxFactories: Seq[BlackBoxFactory]): FirrtlTerp = {
+    val ast = firrtl.Parser.parse(input.split("\n").toIterator)
+    val options = InterpreterOptions(blackBoxFactories = blackBoxFactories, setVerbose = verbose)
     val interpreter = new FirrtlTerp(ast, options)
 
     /* run the circuit once to get the circuit state fully populated. Evaluate all makes sure both

--- a/src/main/scala/firrtl_interpreter/InterpretiveTester.scala
+++ b/src/main/scala/firrtl_interpreter/InterpretiveTester.scala
@@ -24,9 +24,9 @@ class InterpretiveTester(
 
   firrtl_interpreter.random.setSeed(optionsManager.interpreterOptions.randomSeed)
 
-  val interpreter        = FirrtlTerp(input, blackBoxFactories = optionsManager.interpreterOptions.blackBoxFactories)
-  val interpreterOptions = optionsManager.interpreterOptions
-  val commonOptions      = optionsManager.commonOptions
+  val interpreter: FirrtlTerp                = FirrtlTerp(input, optionsManager.interpreterOptions)
+  val interpreterOptions: InterpreterOptions = optionsManager.interpreterOptions
+  val commonOptions: firrtl.CommonOptions    = optionsManager.commonOptions
 
   interpreter.evaluator.allowCombinationalLoops = interpreterOptions.allowCycles
   interpreter.evaluator.useTopologicalSortedKeys = interpreterOptions.setOrderedExec
@@ -48,7 +48,7 @@ class InterpretiveTester(
     interpreter.setVerbose(value)
   }
 
-  val startTime = System.nanoTime()
+  val startTime: Long = System.nanoTime()
 
   /**
     * Pokes value to the port referenced by string

--- a/src/test/scala/firrtl_interpreter/RegisterSpec.scala
+++ b/src/test/scala/firrtl_interpreter/RegisterSpec.scala
@@ -21,7 +21,7 @@ class RegisterSpec extends FlatSpec with Matchers {
         |
       """.stripMargin
 
-    val interpreter = FirrtlTerp(input, verbose = true)
+    val interpreter = FirrtlTerp(input, InterpreterOptions(setVerbose = true))
 
     def makeValue(value: BigInt): Concrete = ConcreteUInt(value, 1)
 


### PR DESCRIPTION
Per @azidar Should use defname when getting names for external modules

Do better passing of options into interpreter, too many were being lost before