### PR TITLE
Fetch resource files as resources.

### DIFF
--- a/src/test/scala/firrtl_interpreter/vcd/VCDSpec.scala
+++ b/src/test/scala/firrtl_interpreter/vcd/VCDSpec.scala
@@ -3,10 +3,12 @@
 package firrtl_interpreter.vcd
 
 import firrtl_interpreter.{InterpreterOptionsManager, InterpretiveTester}
+import firrtl.util.BackendCompilationUtilities
+import java.io.File
 import org.scalatest.{Matchers, FlatSpec}
 
 // scalastyle:off magic.number
-class VCDSpec extends FlatSpec with Matchers {
+class VCDSpec extends FlatSpec with Matchers with BackendCompilationUtilities {
   private def getVcd = {
     VCD("test_circuit")
   }
@@ -70,7 +72,10 @@ class VCDSpec extends FlatSpec with Matchers {
   behavior of "VCD reader"
 
   it should "be able to read a file" in {
-    val vcdFile = VCD.read("src/test/resources/GCD.vcd")
+    val tempFile = File.createTempFile("GCD", ".vcd")
+    tempFile.deleteOnExit()
+    copyResourceToFile("/GCD.vcd", tempFile)
+    val vcdFile = VCD.read(tempFile.getCanonicalPath)
 
     vcdFile.date should be ("2016-10-13T16:31+0000")
   }


### PR DESCRIPTION
This is similar to pr ucb-bar/firrtl#392 and ucb-bar/firrtl#399 - fetch the resource as a resource, not as a random file otherwise the test will fail if it is executed anywhere outside of the actual source directory.