### PR TITLE
Right shift can shift all bits out. 

### DIFF
--- a/src/main/scala/firrtl_interpreter/Concrete.scala
+++ b/src/main/scala/firrtl_interpreter/Concrete.scala
@@ -152,7 +152,6 @@ trait Concrete {
     case ConcreteUInt(thatValue, _, _) =>
       val shift = thatValue.toInt
       assert(shift >= 0, s"ERROR:$this >> $that ${that.value} must be >= 0")
-      assert(shift < this.width, s"ERROR:$this >> $that ${that.value} must be < ${this.width}")
       this match {
         case _: ConcreteUInt => ConcreteUInt(this.value >> shift, this.width)
         case _: ConcreteSInt => ConcreteSInt(this.value >> shift, this.width)
@@ -162,7 +161,6 @@ trait Concrete {
   def >>(that: BigInt): Concrete = >>(that.toInt)
   def >>(shift: Int): Concrete = {
     assert(shift >= 0, s"ERROR:$this >> $shift $shift must be >= 0")
-    assert(shift < this.width, s"ERROR:$this >> $shift $shift must be >= 0")
     this match {
       case ConcreteUInt(thisValue, thisWidth, p) => ConcreteUInt(this.value >> shift, thisWidth - shift, p)
       case ConcreteSInt(thisValue, thisWidth, p) => ConcreteSInt(this.value >> shift, thisWidth - shift, p)
@@ -327,14 +325,14 @@ object Concrete {
   * @param value the BigInt value of this UInt, must be non-negative
   * @param width the number of bits in this value, must be big enough to contain value
   */
-case class ConcreteUInt(val value: BigInt, val width: Int, poisoned: Boolean = false) extends Concrete {
+case class ConcreteUInt(value: BigInt, width: Int, poisoned: Boolean = false) extends Concrete {
   if(width < 0) {
     throw new InterpreterException(s"error: ConcreteUInt($value, $width) bad width $width must be > 0")
   }
   if(value < 0) {
     throw new InterpreterException(s"error: ConcreteUInt($value, $width) bad value $value must be >= 0")
   }
-  val bitsRequired = requiredBitsForUInt(value)
+  val bitsRequired: Int = requiredBitsForUInt(value)
   if((width > 0) && (bitsRequired > width)) {
     throw new InterpreterException(
       s"error: ConcreteUInt($value, $width) bad width $width needs ${requiredBitsForUInt(value)}"
@@ -352,7 +350,7 @@ case class ConcreteUInt(val value: BigInt, val width: Int, poisoned: Boolean = f
   * @param value the BigInt value of this UInt,
   * @param width the number of bits in this value, must be big enough to contain value plus 1 for sign bit
   */
-case class ConcreteSInt(val value: BigInt, val width: Int, poisoned: Boolean = false) extends Concrete {
+case class ConcreteSInt(value: BigInt, width: Int, poisoned: Boolean = false) extends Concrete {
   if(width < 0) {
     throw new InterpreterException(s"error: ConcreteSInt($value, $width) bad width $width must be > 0")
   }
@@ -376,7 +374,7 @@ case class ConcreteSInt(val value: BigInt, val width: Int, poisoned: Boolean = f
   def forceWidth(tpe: Type): ConcreteSInt = forceWidth(typeToWidth(tpe))
   override def toString: String = s"$value.${poisonString}S<$width>"
 }
-case class ConcreteClock(val value: BigInt) extends Concrete {
+case class ConcreteClock(value: BigInt) extends Concrete {
   val width = 1
   val poisoned = false
 

--- a/src/test/scala/firrtl_interpreter/ConcreteSpec.scala
+++ b/src/test/scala/firrtl_interpreter/ConcreteSpec.scala
@@ -422,6 +422,7 @@ class ConcreteSpec extends FlatSpec with Matchers {
       shiftedNum.width should be ((width - shift).max(0))
       shiftedNum.value should be (expectedNum)
     }
+
     def testDynamicShiftRightOp(width: Int, shift: Int): Unit = {
       val num = allOnes(width)
       val expectedNum = num >> shift
@@ -429,13 +430,27 @@ class ConcreteSpec extends FlatSpec with Matchers {
       val target = ConcreteUInt(num, width)
       val shiftArg = ConcreteUInt(shift, requiredBitsForUInt(shift))
 
-      requiredBitsForUInt(num) should be (width)
+      requiredBitsForUInt(num) should be(width)
 
       val result = target >> shiftArg
       // println(s"width $width => num $num arg $shift, target $target result $result")
-//      result.width should be (width)
+      //      result.width should be (width)
+      result.value should be(expectedNum)
+    }
+
+    def testSIntDynamicShiftRightOp(width: Int, shift: Int): Unit = {
+      val num = allOnes(width-1)
+      val expectedNum = -num >> shift
+
+      val target = ConcreteSInt(-num, width)
+      val shiftArg = ConcreteUInt(shift, requiredBitsForUInt(shift))
+
+      requiredBitsForSInt(num) should be (width)
+
+      val result = target >> shiftArg
       result.value should be (expectedNum)
     }
+
     testShiftRightOp(29, 1)
 
     for(i <- 3 to maxWidth + 4) {
@@ -444,9 +459,13 @@ class ConcreteSpec extends FlatSpec with Matchers {
       }
     }
     for(i <- 3 to 20) {
-      val fullShift = allOnes(i)
-      for(arg <- Seq(fullShift - 1, fullShift, fullShift + 1, fullShift + 2)) {
-        testDynamicShiftRightOp(i, arg.toInt)
+      for(shift <- i - 3 to i + 3) {
+        testDynamicShiftRightOp(i, shift)
+      }
+    }
+    for(i <- 3 to 20) {
+      for(shift <- i - 3 to i + 3) {
+        testSIntDynamicShiftRightOp(i, shift)
       }
     }
   }

--- a/src/test/scala/firrtl_interpreter/LoFirrtlExpressionEvaluatorSpec.scala
+++ b/src/test/scala/firrtl_interpreter/LoFirrtlExpressionEvaluatorSpec.scala
@@ -54,7 +54,7 @@ class LoFirrtlExpressionEvaluatorSpec extends FlatSpec with Matchers {
 
   behavior of "Primitive ops"
 
-  val input =
+  val input: String =
     """circuit Test :
       |  module Test :
       |    input clk : Clock
@@ -163,12 +163,6 @@ class LoFirrtlExpressionEvaluatorSpec extends FlatSpec with Matchers {
   it should "throw assertions when parameter is less than zero" in {
     intercept[AssertionError] {
       evaluator.bitOps(Shr, Seq(UIntLiteral(1, IntWidth(3))), Seq(-1), UIntType(IntWidth(3)))
-    }
-    intercept[AssertionError] {
-      evaluator.bitOps(Shr, Seq(UIntLiteral(1, IntWidth(3))), Seq(4), UIntType(IntWidth(3)))
-    }
-    intercept[AssertionError] {
-      evaluator.bitOps(Shr, Seq(UIntLiteral(1, IntWidth(33))), Seq(34), UIntType(IntWidth(3)))
     }
   }
   it should "shift bits n bits to the right" in {


### PR DESCRIPTION
Right shift allows shifts bigger than size of thing being shifted
This brings behavior more in line with verilator and other tools
Updated tests for above
Some style cleanup in both files
/chisel3/issue#524