### PR TITLE
Fixing discrepancies between interpreter's and verilator's vcd output

### DIFF
--- a/src/main/scala/firrtl_interpreter/FirrtlTerp.scala
+++ b/src/main/scala/firrtl_interpreter/FirrtlTerp.scala
@@ -179,8 +179,10 @@ class FirrtlTerp(val ast: Circuit, val interpreterOptions: InterpreterOptions) e
   }
 
   def cycle(showState: Boolean = false): Unit = {
+    log("interpreter cycle called " + "="*80)
     if(checkStopped("cycle")) return
 
+    circuitState.vcdLowerClock()
     circuitState.vcdRaiseClock()
 
     if(circuitState.isStale) {
@@ -200,13 +202,11 @@ class FirrtlTerp(val ast: Circuit, val interpreterOptions: InterpreterOptions) e
       elem.cycle()
     }
 
-//    println(s"FirrtlTerp: cycle complete ${"="*80}\n${sourceState.prettyString()}")
     log(s"check prints")
     evaluator.checkPrints()
     log(s"check stops")
     lastStopResult = evaluator.checkStops()
 
-    log(s"${circuitState.prettyString()}")
     if(stopped) {
       if(stopResult == 0) {
         throw StopException(s"Success: Stop result $stopResult")
@@ -216,10 +216,10 @@ class FirrtlTerp(val ast: Circuit, val interpreterOptions: InterpreterOptions) e
       }
     }
 
-    //    println(s"FirrtlTerp: cycle complete ${"="*80}\n${sourceState.prettyString()}")
-    if(showState) println(s"FirrtlTerp: next state computed ${"="*80}\n${circuitState.prettyString()}")
+    evaluateCircuit()
+    log(s"cycle complete:\n${circuitState.prettyString()}")
 
-    circuitState.vcdLowerClock()
+    if(showState) println(s"FirrtlTerp: next state computed ${"="*80}\n${circuitState.prettyString()}")
   }
 
   def doCycles(n: Int): Unit = {

--- a/src/main/scala/firrtl_interpreter/InterpretiveTester.scala
+++ b/src/main/scala/firrtl_interpreter/InterpretiveTester.scala
@@ -92,6 +92,7 @@ class InterpretiveTester(
 
     try {
       val isRegister = interpreter.circuitState.registers.contains(name)
+      interpreter.circuitState.vcdLowerClock()
       interpreter.setValueWithBigInt(name, value, registerPoke = isRegister)
     }
     catch {
@@ -113,6 +114,7 @@ class InterpretiveTester(
 
     try {
       val isRegister = interpreter.circuitState.registers.contains(name)
+      interpreter.circuitState.vcdLowerClock()
       interpreter.circuitState.setValue(name, value, registerPoke = isRegister)
     }
     catch {

--- a/src/main/scala/firrtl_interpreter/ReplVcdController.scala
+++ b/src/main/scala/firrtl_interpreter/ReplVcdController.scala
@@ -2,28 +2,31 @@
 
 package firrtl_interpreter
 
-import firrtl_interpreter.vcd.{Wire, VCD}
+import firrtl_interpreter.vcd.{VCD, Wire}
+
+import scala.tools.jline.console.ConsoleReader
+import scala.util.matching.Regex
 
 class ReplVcdController(val repl: FirrtlRepl, val interpreter: FirrtlTerp, val vcd: VCD) {
-  val console = repl.console
+  val console: ConsoleReader = repl.console
 
   // The following three elements track state of running the vcd file
-  var currentTime = 0L
-  var currentTimeIndex = 0
-  val timeStamps = vcd.valuesAtTime.keys.toList.sorted.toArray
+  var currentTime: Long = 0L
+  var currentTimeIndex: Int = 0
+  val timeStamps: Array[Long] = vcd.valuesAtTime.keys.toList.sorted.toArray
 
   // The following control the current list state of the vcd file
-  var currentListLocation = 0
-  var currentListSize = 10
+  var currentListLocation: Int = 0
+  var currentListSize: Int = 10
 
-  var testAfterRun = true
-  var runVerbose = true
+  var testAfterRun: Boolean = true
+  var runVerbose: Boolean = true
 
-  val IntPattern = """(-?\d+)""".r
+  val IntPattern: Regex = """(-?\d+)""".r
 
-  val vcdCircuitState = interpreter.circuitState.clone
+  val vcdCircuitState: CircuitState = interpreter.circuitState.clone
 
-  val inputs = {
+  val inputs: Set[String] = {
     vcd.scopeRoot.wires
       .filter { wire =>
         interpreter.circuitState.isInput(wire.name)
@@ -31,7 +34,7 @@ class ReplVcdController(val repl: FirrtlRepl, val interpreter: FirrtlTerp, val v
       .map(_.name).toSet
   }
 
-  val outputs = {
+  val outputs: Set[Wire] = {
     vcd.scopeRoot.wires.filter { wire =>
       interpreter.circuitState.isOutput(wire.name)
     }.toSet
@@ -104,7 +107,7 @@ class ReplVcdController(val repl: FirrtlRepl, val interpreter: FirrtlTerp, val v
 
     if(needToStep) {
       console.println(s"vcd step called at $now")
-      interpreter.cycle(showState = false)
+      interpreter.cycle()
     }
     needToStep
   }
@@ -235,7 +238,7 @@ class ReplVcdController(val repl: FirrtlRepl, val interpreter: FirrtlTerp, val v
         arg match {
           case IntPattern(nString) =>
             for {
-              events <- 0 until nString.toInt
+              _ <- 0 until nString.toInt
               if currentTimeIndex < timeStamps.length
             } {
               doChanges()
@@ -323,7 +326,7 @@ class ReplVcdController(val repl: FirrtlRepl, val interpreter: FirrtlTerp, val v
       case Nil =>
         showCurrent()
       case "all" :: _ =>
-        for(timeIndex <- timeStamps.indices) {
+        for(_ <- timeStamps.indices) {
           show(0, timeStamps.length)
         }
         currentListLocation = currentTimeIndex + 1

--- a/src/test/scala/firrtl_interpreter/GCDTester.scala
+++ b/src/test/scala/firrtl_interpreter/GCDTester.scala
@@ -8,7 +8,7 @@ import org.scalatest.{FlatSpec, Matchers}
 class GCDTester extends FlatSpec with Matchers {
   behavior of "GCD"
 
-  val gcdFirrtl =
+  val gcdFirrtl: String =
     """
       |circuit GCD :
       |  module GCD :
@@ -43,17 +43,17 @@ class GCDTester extends FlatSpec with Matchers {
     val tester = new InterpretiveTester(gcdFirrtl)
     // interpreter.setVerbose()
     List((1, 1, 1), (34, 17, 17), (8, 12, 4)).foreach { case (x, y, z) =>
-      tester.step(1)
+      tester.step()
       tester.poke("io_a", x)
       tester.poke("io_b", y)
       tester.poke("io_e", 1)
-      tester.step(1)
+      tester.step()
 
       tester.poke("io_e", 0)
-      tester.step(1)
+      tester.step()
 
       while (tester.peek("io_v") != Big1) {
-        tester.step(1)
+        tester.step()
       }
       tester.expect("io_z", z)
     }

--- a/src/test/scala/firrtl_interpreter/vcd/VCDSpec.scala
+++ b/src/test/scala/firrtl_interpreter/vcd/VCDSpec.scala
@@ -6,7 +6,9 @@ import firrtl_interpreter.{InterpreterOptionsManager, InterpretiveTester}
 import firrtl.CommonOptions
 import firrtl.util.BackendCompilationUtilities
 import java.io.File
-import org.scalatest.{Matchers, FlatSpec}
+
+import logger.LogLevel
+import org.scalatest.{FlatSpec, Matchers}
 
 // scalastyle:off magic.number
 class VCDSpec extends FlatSpec with Matchers with BackendCompilationUtilities {
@@ -107,7 +109,7 @@ class VCDSpec extends FlatSpec with Matchers with BackendCompilationUtilities {
     interpreter.poke("b", -7)
     interpreter.peek("b") should be (BigInt(-7))
 
-    interpreter.step(1)
+    interpreter.step()
     interpreter.peek("c") should be (BigInt(-8))
 
     interpreter.poke("a", 255)
@@ -115,7 +117,7 @@ class VCDSpec extends FlatSpec with Matchers with BackendCompilationUtilities {
     interpreter.poke("b", 249)
     interpreter.peek("b") should be (BigInt(-7))
 
-    interpreter.step(1)
+    interpreter.step()
     interpreter.peek("c") should be (BigInt(-8))
     interpreter.report()
 
@@ -151,5 +153,66 @@ class VCDSpec extends FlatSpec with Matchers with BackendCompilationUtilities {
 //    interpreter.peek("io_c") should be (BigInt(-8))
 
     interpreter.report()
+  }
+
+  behavior of "example from edysusanto"
+
+  it should "align register updates with clock cycles" in {
+    val input =
+      """
+        |circuit pwminCount :
+        |  module pwminCount :
+        |    input clock : Clock
+        |    input reset : UInt<1>
+        |    output io : {testReg : UInt<4>}
+        |
+        |    clock is invalid
+        |    reset is invalid
+        |    io is invalid
+        |    reg testReg : UInt<4>, clock with : (reset => (reset, UInt<1>("h00"))) @[RegisterVCDSpec.scala 30:24]
+        |    node _T_6 = add(testReg, UInt<1>("h01")) @[RegisterVCDSpec.scala 31:22]
+        |    node _T_7 = tail(_T_6, 1) @[RegisterVCDSpec.scala 31:22]
+        |    testReg <= _T_7 @[RegisterVCDSpec.scala 31:11]
+        |    io.testReg <= testReg @[RegisterVCDSpec.scala 32:14]
+        |
+      """.stripMargin
+
+    logger.Logger.globalLevel = LogLevel.Debug
+
+    val manager = new InterpreterOptionsManager {
+      interpreterOptions = interpreterOptions.copy(writeVCD = true)
+      commonOptions = CommonOptions(targetDirName = "test_run_dir/vcd_register_delay")
+    }
+    {
+      val interpreter = new InterpretiveTester(input, manager)
+      //  interpreter.setVerbose()
+      interpreter.poke("reset", 0)
+
+      interpreter.step(50)
+
+      interpreter.report()
+      interpreter.finish
+    }
+
+//    Thread.sleep(3000)
+
+    val vcd = VCD.read("test_run_dir/vcd_register_delay/pwminCount.vcd")
+
+    /* create an ordered indexed list of all the changes to testReg */
+    val eventsOfInterest = vcd.valuesAtTime.filter {
+      case (_, changeSet) =>
+        changeSet.exists { change =>
+          change.wire.name == "testReg"
+        }
+    }.toSeq.sortBy(_._1).map(_._2).toArray
+
+    // at every step the io_testReg should be one cycle behind
+    for(timeStep <- 4 to 24) {
+      def getValue(step: Int, name: String): Int = {
+        eventsOfInterest(step).find { change => change.wire.name == name}.head.value.toInt
+      }
+
+      getValue(timeStep, "testReg") should be (getValue(timeStep, "io_testReg"))
+    }
   }
 }


### PR DESCRIPTION
Values dependent on registers could be a half to a full cycle off, now fixed.
Make a constant for "clock" in VCD
Moved control over vcd output clock in to VCD
Fixed apparent flush problem with VCD writing
Some style cleanup