### PR TITLE
Cleanup of build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,5 @@
+// See LICENSE for license details.
+
 name := "firrtl-interpreter"
 
 organization := "edu.berkeley.cs"
@@ -17,14 +19,13 @@ resolvers ++= Seq(
 // Provide a managed dependency on X if -DXVersion="" is supplied on the command line.
 val defaultVersions = Map("firrtl" -> "1.1-SNAPSHOT")
 
-libraryDependencies ++= (Seq("firrtl").map {
-  dep: String => "edu.berkeley.cs" %% dep % sys.props.getOrElse(dep + "Version", defaultVersions(dep)) })
+libraryDependencies ++= Seq("firrtl").map {
+  dep: String => "edu.berkeley.cs" %% dep % sys.props.getOrElse(dep + "Version", defaultVersions(dep)) }
 
 libraryDependencies ++= Seq(
   "org.scalatest" % "scalatest_2.11" % "2.2.4",
   "org.scalacheck" %% "scalacheck" % "1.12.4",
-  "org.scala-lang.modules" % "scala-jline" % "2.12.1",
-  "com.github.scopt" %% "scopt" % "3.4.0"
+  "org.scala-lang.modules" % "scala-jline" % "2.12.1"
 )
 
 //javaOptions in run ++= Seq(


### PR DESCRIPTION
- Added header
- Removed scopt dependency, this should come from firrtl dependency
This will help with PR to update scopt to 3.5.0 in firrtl