### PR TITLE
Fix BlackBox problem when box has multiple outputs Issue 84

### DIFF
--- a/src/main/scala/firrtl_interpreter/DependencyGraph.scala
+++ b/src/main/scala/firrtl_interpreter/DependencyGraph.scala
@@ -159,9 +159,7 @@ object DependencyGraph extends SimpleLogger {
     for(port <- extModule.ports) {
       if(port.direction == Output) {
         val outputDependencies = instance.outputDependencies(port.name)
-        if(outputDependencies.nonEmpty) {
-          dependencyGraph(expand(port.name)) = BlackBoxOutput(expand(port.name), instance, outputDependencies, port.tpe)
-        }
+        dependencyGraph(expand(port.name)) = BlackBoxOutput(port.name, instance, outputDependencies, port.tpe)
       }
     }
   }

--- a/src/main/scala/firrtl_interpreter/ExternalModule.scala
+++ b/src/main/scala/firrtl_interpreter/ExternalModule.scala
@@ -6,10 +6,14 @@ import firrtl.ir.{Type, Expression, Width}
 
 import scala.collection._
 
-class ExternalModule {
-
-}
-
+/**
+  * During dependency graph processing one of these will be created for each output of
+  * each instantiated black box in the circuit
+  * @param name The name of the output without module name prefix
+  * @param implementation The implementation instance of the parent black box
+  * @param dependentInputs The names of the inputs that this output depends on
+  * @param tpe the concrete return type of this output
+  */
 case class BlackBoxOutput(name: String,
                           implementation: BlackBoxImplementation,
                           dependentInputs: Seq[String],
@@ -19,22 +23,63 @@ case class BlackBoxOutput(name: String,
   def mapType(f: Type => Type): Expression = this
   def mapWidth(f: Width => Width): Expression = this
   def execute(inputValues: Seq[Concrete]): Concrete = {
-    implementation.execute(inputValues, tpe: Type)
+    implementation.execute(inputValues, tpe: Type, name)
   }
   def serialize: String = s"BlackBoxOutput($name,$tpe)"
 }
 
+/**
+  * This is the template for writing scala functions that implement the behaviour of a
+  * black box i.e. [[firrtl.ir.ExtModule]].  Implementing classes should add internal
+  * variables to hold any state information.
+  */
 abstract class BlackBoxImplementation {
   def name: String
   def fullName(componentName: String): String = s"$name.$componentName"
-  def execute(inputValues: Seq[Concrete], tpe: Type): Concrete
+
+  /**
+    * Execute is called to determine the value for the named output at the
+    * current state of the system.
+    * @param inputValues This is a list of concrete values that are in the same order
+    *                    as the outputDependencies lists them
+    * @param tpe         The concrete type of this output
+    * @param outputName  The name of this output
+    * @return            Computed current concrete value for the name output
+    */
+  def execute(inputValues: Seq[Concrete], tpe: Type, outputName: String = ""): Concrete
+
+  /**
+    * Called whenever the cycle command of the interpreter is called.
+    */
   def cycle(): Unit
 
+  /**
+    * returns a list of names of inputs that the nanmed output depends on.
+    * @note The order of this list will determine the order of the inputValues argument to the execute method
+    * @param outputName the output whose dependencies are being described
+    * @return
+    */
   def outputDependencies(outputName: String): Seq[String]
 }
 
+/**
+  * For each instantiation of an ExtModule the interpreter needs a separate instance of
+  * a BlackBoxImplementation. This factory provides it.
+  * @example {{{
+  *   class ExampleBBFactory extends BlackBoxFactory {
+  *     override def createInstatnce(instanceName: String, blackBoxName: String): Option[BlackBoxImplementation] = {
+  *       instanceName match {
+  *         case "bb1" => Some(add(new BB1Impl))
+  *         case "bb2" => Some(add(new BB2Impl))
+  *         case "bb3" => Some(add(new BB3Impl))
+  *         case _ => throw Exeception(s"ExampleBBBFactory does not know how to create $instanceName}")
+  *       }
+  *     }
+  *   }
+  * }}}
+  */
 abstract class BlackBoxFactory {
-  def boxes: mutable.HashMap[String, BlackBoxImplementation] = new mutable.HashMap[String, BlackBoxImplementation]
+  val boxes: mutable.HashMap[String, BlackBoxImplementation] = new mutable.HashMap[String, BlackBoxImplementation]
 
   def add(blackBox: BlackBoxImplementation): BlackBoxImplementation = {
     boxes(blackBox.name) = blackBox
@@ -42,6 +87,10 @@ abstract class BlackBoxFactory {
   }
   def createInstance(instanceName: String, blackBoxName: String): Option[BlackBoxImplementation]
 
+  /**
+    * the factory remembers the implementations it created so the interpreter uses this method to call the
+    * cycle methods of each one
+    */
   def cycle(): Unit = {
     boxes.values.foreach { box => box.cycle() }
   }

--- a/src/main/scala/firrtl_interpreter/LoFirrtlExpressionEvaluator.scala
+++ b/src/main/scala/firrtl_interpreter/LoFirrtlExpressionEvaluator.scala
@@ -373,10 +373,10 @@ class LoFirrtlExpressionEvaluator(val dependencyGraph: DependencyGraph, val circ
           v.forceWidth(tpe)
         case c: UIntLiteral => Concrete(c).forceWidth(c.tpe)
         case c: SIntLiteral => Concrete(c).forceWidth(c.tpe)
-        case blackBox: BlackBoxOutput =>
-          log(s"got a black box, $blackBox")
-          val concreteInputs = blackBox.dependentInputs.map { input => getValue(input)}
-          blackBox.execute(concreteInputs)
+        case blackBoxOutput: BlackBoxOutput =>
+          log(s"got a black box, $blackBoxOutput")
+          val concreteInputs = blackBoxOutput.dependentInputs.map { input => getValue(input)}
+          blackBoxOutput.execute(concreteInputs)
       }
     }
     catch {

--- a/src/main/scala/firrtl_interpreter/real/DspRealBlackBox.scala
+++ b/src/main/scala/firrtl_interpreter/real/DspRealBlackBox.scala
@@ -27,7 +27,7 @@ abstract class DspRealTwoArgumentToDouble extends BlackBoxImplementation {
     }
   }
   def cycle(): Unit = {}
-  def execute(inputValues: Seq[Concrete], tpe: Type): Concrete = {
+  def execute(inputValues: Seq[Concrete], tpe: Type, outputName: String): Concrete = {
     val arg1 :: arg2 :: _ = inputValues
     val doubleArg1 = bigIntBitsToDouble(arg1.value)
     val doubleArg2 = bigIntBitsToDouble(arg2.value)
@@ -55,7 +55,7 @@ abstract class DspRealOneArgumentToDouble extends BlackBoxImplementation {
     }
   }
   def cycle(): Unit = {}
-  def execute(inputValues: Seq[Concrete], tpe: Type): Concrete = {
+  def execute(inputValues: Seq[Concrete], tpe: Type, outputName: String): Concrete = {
     val arg1 :: _ = inputValues
     val doubleArg1 = bigIntBitsToDouble(arg1.value)
     val doubleResult = oneOp(doubleArg1)
@@ -81,7 +81,7 @@ abstract class DspRealTwoArgumentToBoolean extends BlackBoxImplementation {
     }
   }
   def cycle(): Unit = {}
-  def execute(inputValues: Seq[Concrete], tpe: Type): Concrete = {
+  def execute(inputValues: Seq[Concrete], tpe: Type, outputName: String): Concrete = {
     val arg1 :: arg2 :: _ = inputValues
     val doubleArg1 = bigIntBitsToDouble(arg1.value)
     val doubleArg2 = bigIntBitsToDouble(arg2.value)
@@ -146,7 +146,7 @@ class DspRealToInt(val name: String) extends BlackBoxImplementation {
     }
   }
   def cycle(): Unit = {}
-  def execute(inputValues: Seq[Concrete], tpe: Type): Concrete = {
+  def execute(inputValues: Seq[Concrete], tpe: Type, outputName: String): Concrete = {
     val arg1 :: _ = inputValues
     val result = arg1.value
     TypeInstanceFactory(tpe, result)
@@ -161,7 +161,7 @@ class DspRealFromInt(val name: String) extends BlackBoxImplementation {
     }
   }
   def cycle(): Unit = {}
-  def execute(inputValues: Seq[Concrete], tpe: Type): Concrete = {
+  def execute(inputValues: Seq[Concrete], tpe: Type, outputName: String): Concrete = {
     val arg1 :: _ = inputValues
     val result = arg1.value
     TypeInstanceFactory(tpe, result)

--- a/src/test/scala/firrtl_interpreter/BlackBoxOutputSpec.scala
+++ b/src/test/scala/firrtl_interpreter/BlackBoxOutputSpec.scala
@@ -1,0 +1,160 @@
+// See LICENSE for license details.
+
+package firrtl_interpreter
+
+import firrtl.ExecutionOptionsManager
+import firrtl.ir.Type
+import org.scalatest.{FreeSpec, Matchers}
+
+//scalastyle:off magic.number
+
+/**
+  * Illustrate a black box that has multiple outputs
+  * This one creates 3 outputs each with a different increment of the input
+  */
+class FanOutAdder extends BlackBoxImplementation {
+  override def name: String = "FanOutAdder"
+
+  override def execute(inputValues: Seq[Concrete], tpe: Type, outputName: String): Concrete = {
+    val inc = outputName match {
+      case "out1" => 1
+      case "out2" => 2
+      case "out3" => 3
+    }
+    inputValues.head + ConcreteUInt(inc, 3)
+  }
+
+  override def cycle(): Unit = {}
+
+  override def outputDependencies(outputName: String): Seq[String] = {
+    outputName match {
+      case "out1" => Seq("in")
+      case "out2" => Seq("in")
+      case "out3" => Seq("in")
+      case _ => throw InterpreterException(s"$name was asked for input dependency for unknown output $outputName")
+    }
+  }
+}
+
+class FanOutAdderFactory extends BlackBoxFactory {
+  override def createInstance(instanceName: String, blackBoxName: String): Option[BlackBoxImplementation] = {
+    Some(add(new FanOutAdder))
+  }
+}
+
+class BlackBoxCounter extends BlackBoxImplementation {
+  val name: String = "BlackBoxCounter"
+  var counter = BigInt(0)
+
+  def execute(inputValues: Seq[Concrete], tpe: Type, outputName: String): Concrete = {
+    if(inputValues.head.value == Big1) {
+      counter = 0
+    }
+    TypeInstanceFactory(tpe, counter)
+  }
+
+  override def cycle(): Unit = {
+    counter += 1
+  }
+
+  override def outputDependencies(outputName: String): Seq[String] = {
+    Seq("clear")
+  }
+}
+
+class BlackBoxCounterFactory extends BlackBoxFactory {
+  override def createInstance(instanceName: String, blackBoxName: String): Option[BlackBoxImplementation] = {
+    Some(add(new BlackBoxCounter))
+  }
+}
+
+class BlackBoxOutputSpec extends FreeSpec with Matchers {
+  "this tests black box implmentation that have multiple outputs" - {
+    val adderInput =
+      """
+        |circuit FanOutTest :
+        |  extmodule FanOut :
+        |    output out1 : UInt<64>
+        |    output out2 : UInt<64>
+        |    output out3 : UInt<64>
+        |    input in : UInt<64>
+        |
+        |
+        |  module FanOutTest :
+        |    input clk : Clock
+        |    input reset : UInt<1>
+        |    input in : UInt<64>
+        |    output out1 : UInt<64>
+        |    output out2 : UInt<64>
+        |    output out3 : UInt<64>
+        |
+        |    inst fo of FanOut
+        |    fo.in <= in
+        |    out1 <= fo.out1
+        |    out2 <= fo.out2
+        |    out3 <= fo.out3
+      """.stripMargin
+
+    "each output should hold a different values" in {
+
+      val factory = new FanOutAdderFactory
+
+      val optionsManager = new ExecutionOptionsManager("interpreter") with HasInterpreterOptions {
+        interpreterOptions = InterpreterOptions(blackBoxFactories = Seq(factory), randomSeed = 0L)
+      }
+      val tester = new InterpretiveTester(adderInput, optionsManager)
+      tester.interpreter.verbose = true
+      tester.interpreter.setVerbose()
+
+      for(i <- 0 until 10) {
+        tester.poke("in", i)
+        tester.expect("out1", i + 1)
+        tester.expect("out2", i + 2)
+        tester.expect("out3", i + 3)
+        tester.step()
+      }
+    }
+  }
+
+  "this test a black box of an accumulator that implements reset" - {
+    val input =
+      """
+        |circuit CounterTest :
+        |  extmodule BlackBoxCounter :
+        |    output counter : UInt<64>
+        |    input clear : UInt<1>
+        |
+        |
+        |  module CounterTest :
+        |    input clk : Clock
+        |    input reset : UInt<1>
+        |    input clear : UInt<64>
+        |    output counter : UInt<64>
+        |
+        |    inst bbc of BlackBoxCounter
+        |    bbc.clear <= clear
+        |    counter <= bbc.counter
+      """.stripMargin
+
+    "each output should hold a different values" in {
+
+      val factory = new BlackBoxCounterFactory
+
+      val optionsManager = new ExecutionOptionsManager("interpreter") with HasInterpreterOptions {
+        interpreterOptions = InterpreterOptions(blackBoxFactories = Seq(factory), randomSeed = 0L)
+      }
+      val tester = new InterpretiveTester(input, optionsManager)
+      tester.interpreter.verbose = true
+      tester.interpreter.setVerbose()
+
+      tester.poke("clear", 1)
+      tester.step()
+      tester.poke("clear", 0)
+
+      for(i <- 0 until 10) {
+        tester.expect("counter", i)
+        tester.step()
+      }
+    }
+  }
+}


### PR DESCRIPTION
THIS BREAKS EXISTING API.  EXECUTE CALL NOW REQUIRES OUTPUT NAME

- Add output name to execute method
- Better doc in black box implementation
- Added some more tests of black boxes with multiple outputs and internal state
- Fixed problem where black boxes with no input dependencies did not work
- Updated internal examples that used black boxes